### PR TITLE
Add Node test setup with coverage enforcement

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "dev": "nodemon",
-    "start": "ts-node src/index.ts"
+    "start": "ts-node src/index.ts",
+    "test": "node --require ts-node/register --test --experimental-test-coverage test/getGroupedReasoningWarning.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/test/getGroupedReasoningWarning.test.ts
+++ b/backend/test/getGroupedReasoningWarning.test.ts
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getGroupedReasoningWarning } from '../src/utils/getGroupedReasoningWarning';
+import { Question } from '../src/types/Questions';
+
+const makeQuestion = (id: number, text: string): Question => ({
+  questionId: id,
+  questionText: text,
+  shortQuestionText: text,
+  description: '',
+  questionType: 'classification',
+  group: '',
+  dependencies: [],
+  choices: [],
+});
+
+test('returns empty string when no other questions', () => {
+  const q = makeQuestion(1, 'First question');
+  const warning = getGroupedReasoningWarning([q], q);
+  assert.equal(warning, '');
+});
+
+test('returns warning when other questions exist', () => {
+  const q1 = makeQuestion(1, 'First question');
+  const q2 = makeQuestion(2, 'Second question');
+  const warning = getGroupedReasoningWarning([q1, q2], q1);
+  assert.ok(warning.includes('Note:'));
+  assert.ok(warning.includes('Q1:'));
+  assert.ok(warning.includes('Q2:'));
+  assert.ok(
+    warning.includes(
+      'Please ensure that that you only use the reasoning that is relevant to this question'
+    )
+  );
+});
+

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output=$(npm test --prefix backend "$@" 2>&1)
+status=$?
+printf '%s\n' "$output"
+if [ $status -ne 0 ]; then
+  exit $status
+fi
+
+line_pct=$(echo "$output" | grep 'all files' | awk -F'|' '{print $2}' | tr -d ' ')
+line_pct_int=${line_pct%.*}
+if [ "$line_pct_int" -lt 80 ]; then
+  echo "Line coverage ${line_pct} below threshold 80%"
+  exit 1
+fi
+


### PR DESCRIPTION
## Summary
- add Node test script to backend with built-in coverage
- create unit tests for `getGroupedReasoningWarning`
- add `test.sh` to run tests and enforce 80% line coverage

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c80f3253808330bdd2c3903457d9b1