### PR TITLE
feat: add api key modal and pricing config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Work in Progress**
 
-This monorepo contains the first API in the WR API Suite. It generates an augmented question set with rich metadata from any textual input and then uses that set to evaluate large volumes of documents. The same pipeline can power many workflows: scoring CVs for a role, auditing customer service conversations, or running continuous quality checks on arbitrary log batches. Results are produced with full reasoning, metadata, and auditability.
+This monorepo contains the first API in the WR API Suite. It generates an augmented question set with rich metadata from any textual input and then uses that set to evaluate large volumes of documents. The same pipeline can power many workflows: scoring CVs for a role, auditing customer service snippets, or running continuous quality checks on arbitrary log batches. Results are produced with full reasoning, metadata, and auditability.
 
 Batch jobs run in the background when triggered by the consumer. A status endpoint lets clients poll progress, and generated results remain available for a short time-to-live window for download (and can be deleted early by the user).
 

--- a/backend/src/config/pricing.json
+++ b/backend/src/config/pricing.json
@@ -1,0 +1,4 @@
+{
+  "questionGeneration": 0.01,
+  "questionAnswering": 0.02
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,6 +4,7 @@ import questionsRouter from "./routes/questions";
 import accountRouter from "./routes/account";
 import { apiKeyAuth } from "./utils/apiKeyAuth";
 import cors from "cors";
+import pricingRouter from "./routes/pricing";
 
 import path from "path";
 
@@ -18,6 +19,7 @@ app.use("/data", express.static(path.join(__dirname, "../../data")));
 
 // account management
 app.use("/api/account", accountRouter);
+app.use("/api/pricing", pricingRouter);
 
 // main API router with API key auth
 app.use("/api/questions", apiKeyAuth, questionsRouter);

--- a/backend/src/routes/pricing.ts
+++ b/backend/src/routes/pricing.ts
@@ -1,0 +1,10 @@
+import express from "express";
+import pricing from "../config/pricing.json";
+
+const router = express.Router();
+
+router.get("/", (_req, res) => {
+  res.json(pricing);
+});
+
+export default router;

--- a/frontend/components/ApiKeyModal.tsx
+++ b/frontend/components/ApiKeyModal.tsx
@@ -1,0 +1,69 @@
+import { useState, useEffect } from "react";
+
+export default function ApiKeyModal() {
+  const [apiKey, setApiKey] = useState("");
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = localStorage.getItem("apiKey");
+    if (!stored) {
+      setShow(true);
+    }
+  }, []);
+
+  const save = () => {
+    if (typeof window !== "undefined" && apiKey) {
+      localStorage.setItem("apiKey", apiKey);
+    }
+    setShow(false);
+  };
+
+  if (!show) return null;
+
+  return (
+    <div className="modal">
+      <div className="modal-content">
+        <h2>Enter API Key</h2>
+        <input
+          type="password"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+        />
+        <button onClick={save}>Save</button>
+      </div>
+      <style jsx>{`
+        .modal {
+          position: fixed;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          background: rgba(0, 0, 0, 0.5);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          z-index: 1000;
+        }
+        .modal-content {
+          background: #fff;
+          padding: 1rem;
+          border-radius: 4px;
+          box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+          display: flex;
+          flex-direction: column;
+          gap: 0.5rem;
+          min-width: 300px;
+        }
+        input {
+          padding: 0.5rem;
+          font-size: 1rem;
+        }
+        button {
+          align-self: flex-end;
+          padding: 0.5rem 1rem;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -3,7 +3,12 @@ export async function fetchJSON<T>(
   url: string,
   opts?: RequestInit
 ): Promise<T> {
-  const res = await fetch(url, opts);
+  const headers = new Headers(opts?.headers || {});
+  if (typeof window !== "undefined") {
+    const apiKey = localStorage.getItem("apiKey");
+    if (apiKey) headers.set("x-api-key", apiKey);
+  }
+  const res = await fetch(url, { ...opts, headers });
   if (!res.ok) throw new Error(await res.text());
   return res.json();
 }

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -2,6 +2,7 @@ import { QAResult, QuestionSet } from "@/types/Questions";
 import { AppProps } from "next/app";
 import Link from "next/link";
 import { useState } from "react";
+import ApiKeyModal from "@/components/ApiKeyModal";
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   const [questionSet, setQuestionSet] = useState<QuestionSet | null>(null);
@@ -10,15 +11,15 @@ export default function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <div className="app-layout">
+      <ApiKeyModal />
       <nav className="app-nav">
         <div className="nav-links">
           <Link href="/questions">Questions</Link>
           {questionSet && (
             <>
-              {" "}
-              |{" "}
-              <Link href="/conversations">
-                Conversations
+              {" "}|{" "}
+              <Link href="/snippets">
+                Snippets
                 {Object.keys(snippets).length > 0
                   ? ` (${Object.keys(snippets).length})`
                   : ""}
@@ -28,6 +29,9 @@ export default function MyApp({ Component, pageProps }: AppProps) {
         </div>
         <div className="nav-title">
           {questionSet?.title || "No question set loaded"}
+        </div>
+        <div className="nav-links">
+          <Link href="/account/billing">Account &amp; Billing</Link>
         </div>
       </nav>
       <main className="app-content">
@@ -65,6 +69,10 @@ export default function MyApp({ Component, pageProps }: AppProps) {
           background: #ffffff;
           box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
         }
+        .nav-links {
+          display: flex;
+          align-items: center;
+        }
         .app-nav a {
           margin: 0 0.75rem;
           color: #1890ff;
@@ -84,6 +92,8 @@ export default function MyApp({ Component, pageProps }: AppProps) {
         .nav-title {
           font-size: 1rem;
           font-weight: 500;
+          flex: 1;
+          text-align: center;
         }
       `}</style>
     </div>

--- a/frontend/pages/account/billing.tsx
+++ b/frontend/pages/account/billing.tsx
@@ -14,9 +14,17 @@ type UserData = {
   apiKeys: { id: string; key: string }[];
 };
 
+type Pricing = {
+  questionGeneration: number;
+  questionAnswering: number;
+};
+
+const mask = (key: string) => key.replace(/.(?=.{4})/g, "*");
+
 export default function BillingPage() {
   const [data, setData] = useState<UserData | null>(null);
   const [amount, setAmount] = useState<number>(0);
+  const [pricing, setPricing] = useState<Pricing | null>(null);
 
   const load = async () => {
     const res = await fetch(`${API_URL}/api/account`);
@@ -26,6 +34,9 @@ export default function BillingPage() {
 
   useEffect(() => {
     load();
+    fetch(`${API_URL}/api/pricing`)
+      .then((r) => r.json())
+      .then(setPricing);
   }, []);
 
   const topUp = async () => {
@@ -50,37 +61,95 @@ export default function BillingPage() {
   if (!data) return <div>Loading...</div>;
 
   return (
-    <div style={{ padding: "1rem" }}>
-      <h1>Usage & Billing</h1>
-      <p>Credits: {data.credits.toFixed(2)}</p>
-      <div>
-        <input
-          type="number"
-          value={amount}
-          onChange={(e) => setAmount(Number(e.target.value))}
-          placeholder="Amount"
-        />
-        <button onClick={topUp}>Top Up</button>
+    <div className="container">
+      <h1>Usage &amp; Billing</h1>
+      {pricing && (
+        <div className="card">
+          <h2>Pricing</h2>
+          <p>
+            Question generation: ${pricing.questionGeneration.toFixed(2)} per
+            question
+          </p>
+          <p>
+            Question answering: ${pricing.questionAnswering.toFixed(2)} per
+            question
+          </p>
+        </div>
+      )}
+      <div className="card">
+        <p>Credits: {data.credits.toFixed(2)}</p>
+        <div className="topup">
+          <input
+            type="number"
+            value={amount}
+            onChange={(e) => setAmount(Number(e.target.value))}
+            placeholder="Amount"
+          />
+          <button onClick={topUp}>Top Up</button>
+        </div>
       </div>
 
-      <h2>API Keys</h2>
-      <ul>
-        {data.apiKeys.map((k, idx) => (
-          <li key={k.id}>
-            <code>{k.key}</code>
-            <button onClick={() => rotate(idx)}>Rotate</button>
-          </li>
-        ))}
-      </ul>
+      <div className="card">
+        <h2>API Keys</h2>
+        <ul>
+          {data.apiKeys.map((k, idx) => (
+            <li key={k.id}>
+              <code>{mask(k.key)}</code>
+              <button onClick={() => rotate(idx)}>Rotate</button>
+            </li>
+          ))}
+        </ul>
+      </div>
 
-      <h2>Usage</h2>
-      <ul>
-        {data.usage.map((u, idx) => (
-          <li key={idx}>
-            {u.timestamp}: {u.action} - {u.cost}
-          </li>
-        ))}
-      </ul>
+      <div className="card">
+        <h2>Usage</h2>
+        <ul>
+          {data.usage.map((u, idx) => (
+            <li key={idx}>
+              {u.timestamp}: {u.action} - {u.cost}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <style jsx>{`
+        .container {
+          display: flex;
+          flex-direction: column;
+          flex: 1 1 auto;
+          background: #f0f2f5;
+          padding: 1rem;
+          gap: 1rem;
+        }
+        .card {
+          background: #fff;
+          padding: 1rem;
+          border-radius: 4px;
+          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        }
+        .topup {
+          display: flex;
+          gap: 0.5rem;
+          margin-top: 0.5rem;
+        }
+        ul {
+          list-style: none;
+          padding: 0;
+        }
+        li {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          padding: 0.25rem 0;
+        }
+        input {
+          padding: 0.5rem;
+          flex: 1;
+        }
+        button {
+          padding: 0.5rem 1rem;
+        }
+      `}</style>
     </div>
   );
 }

--- a/frontend/pages/questions.tsx
+++ b/frontend/pages/questions.tsx
@@ -9,7 +9,6 @@ import {
   QAResult,
 } from "@/types/Questions";
 import { useState, useEffect, useRef, useLayoutEffect } from "react";
-import Link from "next/link";
 import DynamicWidthTextarea from "@/components/DynamicWidthTextarea";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
@@ -123,7 +122,10 @@ const QuestionSetPage: React.FC<
   const openModal = () => setShowModal(true);
   const closeModal = () => setShowModal(false);
   const openLoadModal = async () => {
-    const res = await fetch(`${API_URL}/api/questions`);
+    const apiKey = getApiKey();
+    const res = await fetch(`${API_URL}/api/questions`, {
+      headers: apiKey ? { "x-api-key": apiKey } : undefined,
+    });
     const data: {
       id: string;
       title: string;
@@ -142,13 +144,20 @@ const QuestionSetPage: React.FC<
         "Are you sure you want to delete this question set? This action cannot be undone."
       )
     ) {
-      await fetch(`${API_URL}/api/questions/${id}`, { method: "DELETE" });
+      const apiKey = getApiKey();
+      await fetch(`${API_URL}/api/questions/${id}`, {
+        method: "DELETE",
+        headers: apiKey ? { "x-api-key": apiKey } : undefined,
+      });
       setAvailableSets((prev) => prev.filter((s) => s.id !== id));
     }
   };
 
   const loadQuestionSet = async (id: string) => {
-    const res = await fetch(`${API_URL}/api/questions/${id}`);
+    const apiKey = getApiKey();
+    const res = await fetch(`${API_URL}/api/questions/${id}`, {
+      headers: apiKey ? { "x-api-key": apiKey } : undefined,
+    });
     const set: QuestionSet = await res.json();
 
     setQuestionSet(set);
@@ -170,9 +179,13 @@ const QuestionSetPage: React.FC<
     setLogs([]);
     setStreamComplete(false);
 
+    const apiKey = getApiKey();
     const res = await fetch(`${API_URL}/api/questions`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...(apiKey ? { "x-api-key": apiKey } : {}),
+      },
       body: JSON.stringify({ changeRequest: userInput }),
     });
     if (!res.body) return;
@@ -271,11 +284,11 @@ const QuestionSetPage: React.FC<
     }
   }, [selectedQuestion]);
 
+  const getApiKey = () =>
+    typeof window !== "undefined" ? localStorage.getItem("apiKey") : null;
+
   return (
     <main className="container">
-      <div style={{ textAlign: "right" }}>
-        <Link href="/account/billing">Account &amp; Billing</Link>
-      </div>
       {showModal && (
         <div className="modal">
           {!isGenerating && !streamComplete && (
@@ -1256,9 +1269,9 @@ const QuestionSetPage: React.FC<
       <div className="bottom-content">
         <div className="panel desc-panel" tabIndex={0}>
           <div className="field">
-            <label htmlFor="conversation-desc">Conversation Description</label>
+            <label htmlFor="snippet-desc">Snippet Description</label>
             <DynamicWidthTextarea
-              id="conversation-desc"
+              id="snippet-desc"
               readOnly={!editingDesc}
               value={snippetType}
               growVertically={true}
@@ -1276,8 +1289,8 @@ const QuestionSetPage: React.FC<
               onClick={() => setEditingDesc((v) => !v)}
               aria-label={
                 editingDesc
-                  ? "Save conversation description"
-                  : "Edit conversation description"
+                  ? "Save snippet description"
+                  : "Edit snippet description"
               }
             >
               {editingDesc ? "💾" : "✏️"}

--- a/frontend/pages/snippets.tsx
+++ b/frontend/pages/snippets.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from "react";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
 
-export default function ConversationsPage(props: {
+export default function SnippetsPage(props: {
   questionSet: QuestionSet | null;
   snippets: Record<string, QAResult>;
   setSnippets: React.Dispatch<React.SetStateAction<Record<string, QAResult>>>;
@@ -38,6 +38,8 @@ export default function ConversationsPage(props: {
   }, [props.questionSet]);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const getApiKey = () =>
+    typeof window !== "undefined" ? localStorage.getItem("apiKey") : null;
 
   const handleBrowse = async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files) return;
@@ -60,9 +62,14 @@ export default function ConversationsPage(props: {
       e.target.value = "";
       return;
     }
+    const apiKey = getApiKey();
+    const headers: Record<string, string> = props.questionSet
+      ? { questionSetId: props.questionSet.id }
+      : {};
+    if (apiKey) headers["x-api-key"] = apiKey;
     const res = await fetch(`${API_URL}/api/upload`, {
       method: "POST",
-      headers: props.questionSet ? { questionSetId: props.questionSet.id } : {},
+      headers,
       body: form,
     });
     if (!res.body) return;
@@ -175,6 +182,7 @@ export default function ConversationsPage(props: {
 
       switch (event) {
         case "conversation":
+        case "snippet":
           // ensure answers object exists
           break;
         case "linkFileToSnippet":
@@ -309,9 +317,14 @@ export default function ConversationsPage(props: {
     }
 
     // Include questionSetId header if provided
+    const apiKey = getApiKey();
+    const headers: Record<string, string> = props.questionSet
+      ? { questionSetId: props.questionSet.id }
+      : {};
+    if (apiKey) headers["x-api-key"] = apiKey;
     const res = await fetch(`${API_URL}/api/upload`, {
       method: "POST",
-      headers: props.questionSet ? { questionSetId: props.questionSet.id } : {},
+      headers,
       body: form,
     });
     if (!res.body) return;
@@ -405,7 +418,7 @@ export default function ConversationsPage(props: {
           {(() => {
             const convEntries = Object.entries(snippets);
             if (convEntries.length === 0) {
-              return <p>No conversations yet.</p>;
+              return <p>No snippets yet.</p>;
             }
             const questions = props.questionSet!.questions as Question[];
 


### PR DESCRIPTION
## Summary
- prompt user for API key via modal and send it with requests
- rename conversations to snippets and move account link into nav bar
- add pricing config endpoint and show pricing with masked keys on billing page

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c819961f7083309e8436c71bcde1ea