### PR TITLE
Improve usage breakdown and snippet feedback

### DIFF
--- a/frontend/components/UsageBreakdown.tsx
+++ b/frontend/components/UsageBreakdown.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+
+export type UsageEntry = {
+  timestamp: string;
+  action: string;
+  tokenCost: number;
+  billedCost: number;
+  requests: number;
+  question?: string;
+};
+
+export default function UsageBreakdown({ entries }: { entries: UsageEntry[] }) {
+  const [filter, setFilter] = useState("");
+  const filtered = entries.filter(
+    (e) =>
+      e.action.toLowerCase().includes(filter.toLowerCase()) ||
+      (e.question || "").toLowerCase().includes(filter.toLowerCase()),
+  );
+  return (
+    <details>
+      <summary>
+        Usage Events ({entries.length})
+      </summary>
+      <input
+        type="text"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        placeholder="Filter by question or action"
+        className="filter"
+      />
+      <table>
+        <thead>
+          <tr>
+            <th>Time</th>
+            <th>Action</th>
+            <th>Question</th>
+            <th>Cost</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map((e, i) => (
+            <tr key={i}>
+              <td>{new Date(e.timestamp).toLocaleString()}</td>
+              <td>{e.action}</td>
+              <td>{e.question || "-"}</td>
+              <td>{e.billedCost.toFixed(2)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <style jsx>{`
+        details {
+          background: #fff;
+          border-radius: 6px;
+          padding: 0.5rem;
+        }
+        summary {
+          cursor: pointer;
+          font-weight: 600;
+          list-style: none;
+        }
+        .filter {
+          margin: 0.5rem 0;
+          padding: 0.25rem 0.5rem;
+          width: 100%;
+          border: 1px solid #ccc;
+          border-radius: 4px;
+        }
+        table {
+          width: 100%;
+          border-collapse: collapse;
+        }
+        th,
+        td {
+          text-align: left;
+          padding: 0.25rem 0.5rem;
+        }
+        tbody tr:nth-child(odd) {
+          background: #f9f9f9;
+        }
+      `}</style>
+    </details>
+  );
+}
+

--- a/frontend/pages/account/billing.tsx
+++ b/frontend/pages/account/billing.tsx
@@ -1,14 +1,7 @@
 import { useEffect, useState } from "react";
+import UsageBreakdown, { UsageEntry } from "@/components/UsageBreakdown";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
-
-type UsageEntry = {
-  timestamp: string;
-  action: string;
-  tokenCost: number;
-  billedCost: number;
-  requests: number;
-};
 
 type ApiKey = {
   id: string;
@@ -173,13 +166,7 @@ export default function BillingPage() {
 
       <div className="card">
         <h2>Usage</h2>
-        <ul>
-          {data.usage.map((u, idx) => (
-            <li key={idx}>
-              {u.timestamp}: {u.action} - {u.billedCost}
-            </li>
-          ))}
-        </ul>
+        <UsageBreakdown entries={data.usage} />
       </div>
 
       <style jsx>{`

--- a/frontend/pages/admin/users.tsx
+++ b/frontend/pages/admin/users.tsx
@@ -1,14 +1,7 @@
 import { useEffect, useState } from "react";
+import UsageBreakdown, { UsageEntry } from "@/components/UsageBreakdown";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
-
-type UsageEntry = {
-  timestamp: string;
-  action: string;
-  tokenCost: number;
-  billedCost: number;
-  requests: number;
-};
 
 type ApiKey = {
   id: string;
@@ -120,13 +113,7 @@ export default function AdminUsers() {
           </div>
           <div className="usage">
             <h3>Usage</h3>
-            <ul>
-              {u.usage.map((e, i) => (
-                <li key={i}>
-                  {e.timestamp}: {e.action} - billed {e.billedCost} (cost {e.tokenCost})
-                </li>
-              ))}
-            </ul>
+            <UsageBreakdown entries={u.usage} />
           </div>
         </div>
       ))}

--- a/frontend/pages/snippets.tsx
+++ b/frontend/pages/snippets.tsx
@@ -27,6 +27,7 @@ export default function SnippetsPage(props: {
     reasoning?: string;
     detailedReasoning?: string;
   } | null>(null);
+  const [processingMsg, setProcessingMsg] = useState<string | null>(null);
 
   const initialHasDropped = snippets && Object.keys(snippets).length > 0;
   const [hasDropped, setHasDropped] = useState(initialHasDropped);
@@ -146,6 +147,11 @@ export default function SnippetsPage(props: {
     }
     if (event === "error") {
       setLogs((prev) => [...prev, `Error: ${data.message}`]);
+      return;
+    }
+    if (event === "snippetCount") {
+      const count = data.count ?? 0;
+      setProcessingMsg(`Received ${count} snippets. Processing...`);
       return;
     }
     if (!data.snippetId) {
@@ -385,6 +391,19 @@ export default function SnippetsPage(props: {
 
   return (
     <>
+      {processingMsg && (
+        <div className="modal-overlay">
+          <div className="modal">
+            <button
+              className="modal-close-button"
+              onClick={() => setProcessingMsg(null)}
+            >
+              ×
+            </button>
+            <p>{processingMsg}</p>
+          </div>
+        </div>
+      )}
       <main className="container" onDragOver={handleContainerDragOver}>
         <input
           ref={fileInputRef}


### PR DESCRIPTION
## Summary
- show processing modal when snippet uploads report count
- add reusable usage breakdown table with filtering
- integrate usage breakdown into billing and admin pages for clearer usage tracking

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c82cc7c2c8833096732d635f0044cb