### PR TITLE
fix: exclude topups from billed totals

### DIFF
--- a/frontend/pages/admin/users.tsx
+++ b/frontend/pages/admin/users.tsx
@@ -64,9 +64,10 @@ export default function AdminUsers() {
             {u.name} - {u.credits.toFixed(2)} credits
           </h2>
           {(() => {
-            const totalRequests = u.usage.reduce((a, b) => a + b.requests, 0);
-            const totalBilled = u.usage.reduce((a, b) => a + b.billedCost, 0);
-            const totalCost = u.usage.reduce((a, b) => a + b.tokenCost, 0);
+            const usage = u.usage.filter((e) => e.action !== "topup");
+            const totalRequests = usage.reduce((a, b) => a + b.requests, 0);
+            const totalBilled = usage.reduce((a, b) => a + b.billedCost, 0);
+            const totalCost = usage.reduce((a, b) => a + b.tokenCost, 0);
             return (
               <p className="summary">
                 {totalRequests} reqs / billed {totalBilled.toFixed(2)} / cost


### PR DESCRIPTION
## Summary
- prevent admin billing summary from counting top-up credits
- compute billed, cost, profit using only usage actions

## Testing
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68c82d93b9fc833092688e6e4823014a