### PR TITLE
Add dev auth, organization management, and secure API keys

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -6,6 +6,7 @@ import { apiKeyAuth } from "./utils/apiKeyAuth";
 import cors from "cors";
 import pricingRouter from "./routes/pricing";
 import adminRouter from "./routes/admin";
+import authRouter from "./routes/auth";
 
 import path from "path";
 
@@ -19,6 +20,7 @@ app.use("/uploads", express.static(path.join(__dirname, "../../uploads")));
 app.use("/data", express.static(path.join(__dirname, "../../data")));
 
 // account management
+app.use("/api/auth", authRouter);
 app.use("/api/account", accountRouter);
 app.use("/api/pricing", pricingRouter);
 app.use("/api/admin", adminRouter);

--- a/backend/src/middleware/requireAuth.ts
+++ b/backend/src/middleware/requireAuth.ts
@@ -1,0 +1,53 @@
+import { RequestHandler } from "express";
+import { verifyDevToken } from "../utils/devAuth";
+import { getOrganization, getUser, toSafeUser } from "../utils/userStore";
+
+export const requireAuth: RequestHandler = async (req, res, next) => {
+  const header = req.header("authorization") || req.header("Authorization");
+  if (!header || !header.startsWith("Bearer ")) {
+    res.status(401).json({ error: "Missing bearer token" });
+    return;
+  }
+
+  const token = header.replace(/^Bearer\s+/i, "");
+  const session = verifyDevToken(token);
+  if (!session) {
+    res.status(401).json({ error: "Invalid or expired token" });
+    return;
+  }
+
+  const user = await getUser(session.userId);
+  if (!user || user.status !== "active") {
+    res.status(403).json({ error: "User account disabled" });
+    return;
+  }
+
+  const orgHeader = req.header("x-org-id");
+  const linkedOrg = user.organizations[0]?.orgId;
+  const activeOrgId = orgHeader || linkedOrg || null;
+
+  if (!activeOrgId) {
+    res.status(400).json({ error: "No organization selected" });
+    return;
+  }
+
+  const org = await getOrganization(activeOrgId);
+  if (!org) {
+    res.status(404).json({ error: "Organization not found" });
+    return;
+  }
+
+  const membership = org.members.find((m) => m.userId === user.id && m.status === "active");
+  const isSysAdmin = user.globalRoles.includes("SYSADMIN");
+  if (!membership && !isSysAdmin) {
+    res.status(403).json({ error: "User does not belong to this organization" });
+    return;
+  }
+  res.locals.user = toSafeUser(user);
+  res.locals.userId = user.id;
+  res.locals.activeOrgId = org.id;
+  res.locals.membership = membership;
+  res.locals.isSysAdmin = isSysAdmin;
+
+  next();
+};

--- a/backend/src/routes/account.ts
+++ b/backend/src/routes/account.ts
@@ -1,57 +1,216 @@
 import express, { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
 import {
-  getUser,
-  topUp,
-  rotateApiKey,
   addKeySet,
+  createOrUpdateOrgUser,
+  getOrganization,
+  getUsersForOrganization,
   removeKeySet,
+  rotateApiKey,
+  toSafeOrganization,
+  toSafeUser,
+  topUpOrganization,
 } from "../utils/userStore";
+import { OrgRole } from "../types/Identity";
 
 const router = Router();
 
-router.get("/", async (_req, res) => {
-  const user = await getUser();
-  res.json(user);
+router.use(requireAuth);
+
+function getEffectiveRoles(res: express.Response): OrgRole[] {
+  const membership =
+    (res.locals.membership as { roles?: OrgRole[] } | undefined) ?? undefined;
+  const isSysAdmin = Boolean(res.locals.isSysAdmin);
+  const baseRoles = membership?.roles ?? [];
+  if (isSysAdmin) {
+    return ["OWNER", "ADMIN", "BILLING", "MEMBER"];
+  }
+  return baseRoles;
+}
+
+function assertPermission(roles: OrgRole[], allowed: OrgRole[]): boolean {
+  return allowed.some((role) => roles.includes(role));
+}
+
+router.get("/", async (req, res) => {
+  const orgId = res.locals.activeOrgId as string;
+  const user = res.locals.user;
+  const roles = getEffectiveRoles(res);
+  const organization = await getOrganization(orgId);
+  if (!organization) {
+    res.status(404).json({ error: "Organization not found" });
+    return;
+  }
+
+  const permissions = {
+    manageBilling: assertPermission(roles, ["OWNER", "BILLING"]),
+    manageKeys: assertPermission(roles, ["OWNER", "ADMIN"]),
+    manageUsers: assertPermission(roles, ["OWNER", "ADMIN"]),
+  };
+
+  res.json({
+    organization: toSafeOrganization(organization),
+    user,
+    permissions,
+  });
+});
+
+router.get("/organizations", async (_req, res) => {
+  const user = res.locals.user as { organizations: { orgId: string }[] };
+  const organizations = (
+    await Promise.all(
+      user.organizations.map(async (link) => {
+        const org = await getOrganization(link.orgId);
+        return org ? toSafeOrganization(org) : null;
+      }),
+    )
+  ).filter(
+    (org): org is ReturnType<typeof toSafeOrganization> => org !== null,
+  );
+
+  res.json({ organizations });
 });
 
 router.post("/topup", express.json(), async (req, res) => {
+  const roles = getEffectiveRoles(res);
+  if (!assertPermission(roles, ["OWNER", "BILLING"])) {
+    res.status(403).json({ error: "Insufficient permissions" });
+    return;
+  }
+
   const { amount } = req.body;
   const num = Number(amount);
   if (!num || num <= 0) {
     res.status(400).json({ error: "Invalid amount" });
     return;
   }
-  const user = await topUp(num);
-  res.json({ credits: user.credits });
+  const orgId = res.locals.activeOrgId as string;
+  const org = await topUpOrganization(orgId, num);
+  res.json({ credits: org.credits });
 });
 
 router.post("/keysets", express.json(), async (req, res) => {
+  const roles = getEffectiveRoles(res);
+  if (!assertPermission(roles, ["OWNER", "ADMIN"])) {
+    res.status(403).json({ error: "Insufficient permissions" });
+    return;
+  }
+
   const { name, description } = req.body;
   if (!name) {
     res.status(400).json({ error: "Name is required" });
     return;
   }
-  const keySet = await addKeySet(name, description || "");
-  res.json(keySet);
+  const orgId = res.locals.activeOrgId as string;
+  const actorId = res.locals.userId as string;
+  const result = await addKeySet(orgId, actorId, name, description || "");
+  res.json(result);
 });
 
 router.delete("/keysets/:id", async (req, res) => {
-  const { id } = req.params;
-  await removeKeySet(id);
+  const roles = getEffectiveRoles(res);
+  if (!assertPermission(roles, ["OWNER", "ADMIN"])) {
+    res.status(403).json({ error: "Insufficient permissions" });
+    return;
+  }
+  const orgId = res.locals.activeOrgId as string;
+  await removeKeySet(orgId, req.params.id);
   res.json({ ok: true });
 });
 
-router.post(
-  "/keysets/:id/keys/:index/rotate",
-  async (req, res) => {
-    const { id, index } = req.params;
-    try {
-      const key = await rotateApiKey(id, Number(index));
-      res.json({ apiKey: key });
-    } catch (e: any) {
-      res.status(400).json({ error: e.message });
-    }
-  },
-);
+router.post("/keysets/:id/keys/:index/rotate", async (req, res) => {
+  const roles = getEffectiveRoles(res);
+  if (!assertPermission(roles, ["OWNER", "ADMIN"])) {
+    res.status(403).json({ error: "Insufficient permissions" });
+    return;
+  }
+
+  const orgId = res.locals.activeOrgId as string;
+  const actorId = res.locals.userId as string;
+  const { id, index } = req.params;
+  const parsed = Number(index);
+  if (Number.isNaN(parsed)) {
+    res.status(400).json({ error: "Invalid key index" });
+    return;
+  }
+  try {
+    const { apiKey, safeKey } = await rotateApiKey(orgId, id, parsed, actorId);
+    res.json({ apiKey, key: safeKey });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    res.status(400).json({ error: message });
+  }
+});
+
+router.get("/users", async (req, res) => {
+  const roles = getEffectiveRoles(res);
+  if (!assertPermission(roles, ["OWNER", "ADMIN", "BILLING"])) {
+    res.status(403).json({ error: "Insufficient permissions" });
+    return;
+  }
+
+  const orgId = res.locals.activeOrgId as string;
+  const org = await getOrganization(orgId);
+  if (!org) {
+    res.status(404).json({ error: "Organization not found" });
+    return;
+  }
+
+  const users = await getUsersForOrganization(orgId);
+  const mapped = users.map((user) => {
+    const membership = org.members.find((m) => m.userId === user.id);
+    return {
+      ...toSafeUser(user),
+      roles: membership?.roles ?? [],
+    };
+  });
+
+  res.json({ members: mapped });
+});
+
+router.post("/users", express.json(), async (req, res) => {
+  const roles = getEffectiveRoles(res);
+  if (!assertPermission(roles, ["OWNER", "ADMIN"])) {
+    res.status(403).json({ error: "Insufficient permissions" });
+    return;
+  }
+
+  const { email, name, roles: requestedRoles, password } = req.body as {
+    email: string;
+    name: string;
+    roles: OrgRole[];
+    password?: string;
+  };
+
+  if (!email || !name || !requestedRoles?.length) {
+    res.status(400).json({ error: "Missing required fields" });
+    return;
+  }
+
+  const allowedRoles: OrgRole[] = ["OWNER", "ADMIN", "BILLING", "MEMBER"];
+  const invalidRole = requestedRoles.find((role) => !allowedRoles.includes(role));
+  if (invalidRole) {
+    res.status(400).json({ error: `Invalid role: ${invalidRole}` });
+    return;
+  }
+
+  const orgId = res.locals.activeOrgId as string;
+  const { user, generatedPassword, isNewUser } = await createOrUpdateOrgUser({
+    orgId,
+    email,
+    name,
+    roles: requestedRoles,
+    password,
+  });
+
+  res.json({
+    user: {
+      ...toSafeUser(user),
+      roles: requestedRoles,
+    },
+    generatedPassword,
+    isNewUser,
+  });
+});
 
 export default router;

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,42 +1,48 @@
-import { Router } from "express";
-import { getUsers, rotateApiKey } from "../utils/userStore";
+import { Router, Response } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import { getOrganizations, rotateApiKey, toSafeOrganization } from "../utils/userStore";
 
 const router = Router();
 
-router.get("/users", async (_req, res) => {
-  const users = await getUsers();
-  const masked = users.map((u) => ({
-    id: u.id,
-    name: u.name,
-    credits: u.credits,
-    usage: u.usage,
-    keySets: u.keySets.map((ks) => ({
-      id: ks.id,
-      name: ks.name,
-      description: ks.description,
-      keys: ks.keys.map((k) => ({
-        id: k.id,
-        key: k.key.replace(/.(?=.{4})/g, "*"),
-        lastRotated: k.lastRotated,
-        usage: k.usage,
-      })),
-    })),
-  }));
-  res.json(masked);
+router.use(requireAuth);
+
+function ensureSysAdmin(res: Response): boolean {
+  if (!res.locals.isSysAdmin) {
+    res.status(403).json({ error: "Admin access required" });
+    return false;
+  }
+  return true;
+}
+
+router.get("/organizations", async (_req, res) => {
+  if (!ensureSysAdmin(res)) return;
+  const orgs = await getOrganizations();
+  res.json({ organizations: orgs.map(toSafeOrganization) });
 });
 
 router.post(
-  "/users/:userId/keysets/:setId/keys/:index/rotate",
+  "/organizations/:orgId/keysets/:setId/keys/:index/rotate",
   async (req, res) => {
-    const { userId, setId, index } = req.params;
+    if (!ensureSysAdmin(res)) return;
+    const { orgId, setId, index } = req.params;
+    const parsed = Number(index);
+    if (Number.isNaN(parsed)) {
+      res.status(400).json({ error: "Invalid key index" });
+      return;
+    }
     try {
-      const key = await rotateApiKey(setId, Number(index), userId);
-      res.json({ apiKey: key });
-    } catch (e: any) {
-      res.status(400).json({ error: e.message });
+      const { apiKey, safeKey } = await rotateApiKey(
+        orgId,
+        setId,
+        parsed,
+        res.locals.userId as string,
+      );
+      res.json({ apiKey, key: safeKey });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      res.status(400).json({ error: message });
     }
   },
 );
 
 export default router;
-

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,0 +1,77 @@
+import express, { Router } from "express";
+import {
+  createOrganizationWithOwner,
+  getOrganization,
+  getUserByEmail,
+  toSafeOrganization,
+  toSafeUser,
+  updateUserLastLogin,
+  verifyPassword,
+} from "../utils/userStore";
+import { issueDevToken } from "../utils/devAuth";
+
+const router = Router();
+
+router.post("/dev/signup", express.json(), async (req, res) => {
+  const { organizationName, ownerEmail, ownerName, ownerPassword, billingEmail } = req.body;
+  if (!organizationName || !ownerEmail || !ownerName || !ownerPassword) {
+    res.status(400).json({ error: "Missing required fields" });
+    return;
+  }
+
+  try {
+    const { organization, owner, apiKeys } = await createOrganizationWithOwner({
+      organizationName,
+      ownerEmail,
+      ownerName,
+      ownerPassword,
+      billingEmail,
+    });
+    const token = issueDevToken(owner.id);
+    await updateUserLastLogin(owner.id);
+    res.json({
+      token,
+      user: toSafeUser(owner),
+      organization: toSafeOrganization(organization),
+      revealedApiKeys: apiKeys,
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    res.status(400).json({ error: message });
+  }
+});
+
+router.post("/dev/login", express.json(), async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    res.status(400).json({ error: "Missing credentials" });
+    return;
+  }
+
+  const user = await getUserByEmail(email);
+  if (!user || !verifyPassword(password, user.passwordHash)) {
+    res.status(401).json({ error: "Invalid credentials" });
+    return;
+  }
+
+  const token = issueDevToken(user.id);
+  await updateUserLastLogin(user.id);
+  const organizations = (
+    await Promise.all(
+      user.organizations.map(async (link) => {
+        const org = await getOrganization(link.orgId);
+        return org ? toSafeOrganization(org) : null;
+      }),
+    )
+  ).filter(
+    (org): org is ReturnType<typeof toSafeOrganization> => org !== null,
+  );
+
+  res.json({
+    token,
+    user: toSafeUser(user),
+    organizations,
+  });
+});
+
+export default router;

--- a/backend/src/routes/uploadRoute.ts
+++ b/backend/src/routes/uploadRoute.ts
@@ -31,8 +31,8 @@ router.post("/", upload, async (req, res) => {
   }
 
   const billResults = async (results: any[]) => {
-    const { userId, keySetId, keyId } = res.locals as {
-      userId: string;
+    const { orgId, keySetId, keyId } = res.locals as {
+      orgId: string;
       keySetId: string;
       keyId: string;
     };
@@ -49,7 +49,15 @@ router.post("/", upload, async (req, res) => {
       0,
     );
     const billed = answered * pricing.questionAnswering;
-    await recordUsage(tokenCost, billed, "snippet_answering", userId, requests, keySetId, keyId);
+    await recordUsage({
+      orgId,
+      tokenCost,
+      billedCost: billed,
+      action: "snippet_answering",
+      requests,
+      keySetId,
+      keyId,
+    });
   };
 
   try {

--- a/backend/src/types/Identity.ts
+++ b/backend/src/types/Identity.ts
@@ -1,0 +1,97 @@
+export type OrgRole = "OWNER" | "ADMIN" | "BILLING" | "MEMBER";
+
+export type GlobalRole = "SYSADMIN";
+
+export interface UsageEntry {
+  timestamp: string;
+  action: string;
+  /** Cost incurred towards OpenAI in dollars */
+  tokenCost: number;
+  /** Amount billed to the client in dollars */
+  billedCost: number;
+  /** Number of OpenAI requests contributing to the cost */
+  requests: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface StoredApiKey {
+  id: string;
+  encryptedKey: string;
+  encryptionIv: string;
+  encryptionAuthTag: string;
+  keyHash: string;
+  lastFour: string;
+  lastRotated: string;
+  usage: UsageEntry[];
+  createdBy: string;
+  createdAt: string;
+}
+
+export interface KeySet {
+  id: string;
+  name: string;
+  description: string;
+  keys: StoredApiKey[];
+  createdBy: string;
+  createdAt: string;
+}
+
+export interface BillingProfile {
+  contactEmail: string;
+  contactName?: string;
+  /** Placeholder for Stripe integration. */
+  stripeCustomerId?: string | null;
+  notes?: string;
+}
+
+export interface OrgMembership {
+  userId: string;
+  roles: OrgRole[];
+  invitedAt: string;
+  joinedAt: string;
+  status: "active" | "invited" | "suspended";
+}
+
+export interface Organization {
+  id: string;
+  name: string;
+  slug: string;
+  credits: number;
+  usage: UsageEntry[];
+  keySets: KeySet[];
+  members: OrgMembership[];
+  billingProfile: BillingProfile;
+  createdAt: string;
+  createdBy: string;
+}
+
+export interface UserOrganizationLink {
+  orgId: string;
+  roles: OrgRole[];
+}
+
+export interface UserAccount {
+  id: string;
+  email: string;
+  name: string;
+  passwordHash: string;
+  globalRoles: GlobalRole[];
+  organizations: UserOrganizationLink[];
+  createdAt: string;
+  lastLoginAt?: string;
+  status: "active" | "disabled";
+}
+
+export interface AuditLogEntry {
+  id: string;
+  timestamp: string;
+  actorId: string;
+  action: string;
+  details?: Record<string, unknown>;
+}
+
+export interface IdentityStoreData {
+  users: Record<string, UserAccount>;
+  organizations: Record<string, Organization>;
+  auditLog: AuditLogEntry[];
+}

--- a/backend/src/utils/devAuth.ts
+++ b/backend/src/utils/devAuth.ts
@@ -1,0 +1,37 @@
+import crypto from "crypto";
+
+/**
+ * Lightweight auth helpers used during local development.
+ *
+ * The module intentionally mimics the shape of what our Keycloak
+ * integration will eventually provide: issue a token for a user and
+ * validate incoming bearer tokens. Swapping in Keycloak later should be
+ * as simple as replacing these functions with calls to the official
+ * SDK.
+ */
+
+const sessions = new Map<string, { userId: string; issuedAt: number }>();
+
+export function issueDevToken(userId: string): string {
+  const token = `dev.${crypto.randomBytes(24).toString("hex")}`;
+  sessions.set(token, { userId, issuedAt: Date.now() });
+  return token;
+}
+
+export function verifyDevToken(token: string): { userId: string } | null {
+  const session = sessions.get(token);
+  if (!session) return null;
+  return { userId: session.userId };
+}
+
+export function revokeDevToken(token: string): void {
+  sessions.delete(token);
+}
+
+export function listActiveSessions(): { token: string; userId: string; issuedAt: number }[] {
+  return Array.from(sessions.entries()).map(([token, data]) => ({
+    token,
+    userId: data.userId,
+    issuedAt: data.issuedAt,
+  }));
+}

--- a/backend/src/utils/userStore.ts
+++ b/backend/src/utils/userStore.ts
@@ -1,218 +1,720 @@
 import fs from "fs/promises";
 import path from "path";
+import crypto from "crypto";
 import { v4 as uuid } from "uuid";
+import {
+  IdentityStoreData,
+  Organization,
+  UserAccount,
+  UsageEntry,
+  StoredApiKey,
+  KeySet,
+  OrgRole,
+  GlobalRole,
+} from "../types/Identity";
 
-export interface UsageEntry {
-  timestamp: string;
-  action: string;
-  /** Cost incurred towards OpenAI in dollars */
-  tokenCost: number;
-  /** Amount billed to the client in dollars */
-  billedCost: number;
-  /** Number of OpenAI requests contributing to the cost */
-  requests: number;
+const IDENTITY_FILE = path.join(__dirname, "../../../data/identity.json");
+const LEGACY_USERS_FILE = path.join(__dirname, "../../../data/users.json");
+
+const KEY_SECRET = process.env.API_KEY_SECRET || "local-dev-secret";
+const HASH_SECRET = process.env.API_KEY_HASH_SECRET || KEY_SECRET;
+
+function deriveEncryptionKey(): Buffer {
+  return crypto.createHash("sha256").update(KEY_SECRET).digest();
 }
 
-export interface ApiKey {
-  id: string;
-  key: string;
-  lastRotated: string;
-  usage: UsageEntry[];
+function now(): string {
+  return new Date().toISOString();
 }
 
-export interface KeySet {
-  id: string;
-  name: string;
-  description: string;
-  keys: ApiKey[]; // always two keys
+async function ensureDirectory() {
+  await fs.mkdir(path.dirname(IDENTITY_FILE), { recursive: true });
 }
 
-export interface UserData {
-  id: string;
-  name: string;
-  credits: number;
-  usage: UsageEntry[];
-  keySets: KeySet[];
+async function saveIdentity(store: IdentityStoreData): Promise<void> {
+  await ensureDirectory();
+  await fs.writeFile(IDENTITY_FILE, JSON.stringify(store, null, 2), "utf-8");
 }
 
-const USERS_FILE = path.join(__dirname, "../../../data/users.json");
-const DEFAULT_USER_ID = "default";
-
-async function saveUsers(users: Record<string, UserData>): Promise<void> {
-  await fs.mkdir(path.dirname(USERS_FILE), { recursive: true });
-  await fs.writeFile(USERS_FILE, JSON.stringify(users, null, 2), "utf-8");
-}
-
-async function loadUsers(): Promise<Record<string, UserData>> {
+async function loadIdentity(): Promise<IdentityStoreData> {
   try {
-    const raw = await fs.readFile(USERS_FILE, "utf-8");
-    return JSON.parse(raw);
+    const raw = await fs.readFile(IDENTITY_FILE, "utf-8");
+    return JSON.parse(raw) as IdentityStoreData;
+  } catch (err) {
+    const store = await migrateLegacyStore();
+    if (store) return store;
+    const bootstrap = await createBootstrapIdentity();
+    await saveIdentity(bootstrap);
+    return bootstrap;
+  }
+}
+
+async function migrateLegacyStore(): Promise<IdentityStoreData | null> {
+  try {
+    const raw = await fs.readFile(LEGACY_USERS_FILE, "utf-8");
+    const legacy = JSON.parse(raw) as Record<string, any>;
+    const [legacyUser] = Object.values(legacy) as any[];
+    if (!legacyUser) return null;
+    const ownerId = uuid();
+    const orgId = uuid();
+    const created = now();
+    const keySets: KeySet[] = (legacyUser.keySets || []).map((set: any) => {
+      const keys = (set.keys || []).map((key: any) => {
+        const plain = key.key || uuid();
+        return createStoredKeyFromPlain(plain, ownerId);
+      });
+      return {
+        id: set.id || uuid(),
+        name: set.name || "Default",
+        description: set.description || "",
+        keys,
+        createdAt: created,
+        createdBy: ownerId,
+      };
+    });
+    const organization: Organization = {
+      id: orgId,
+      name: legacyUser.name || "Legacy Organization",
+      slug: slugify(legacyUser.name || "Legacy Organization"),
+      credits: legacyUser.credits || 0,
+      usage: legacyUser.usage || [],
+      keySets: keySets.length ? keySets : [createDefaultKeySet(ownerId)],
+      members: [
+        {
+          userId: ownerId,
+          roles: ["OWNER", "ADMIN", "BILLING"],
+          invitedAt: created,
+          joinedAt: created,
+          status: "active",
+        },
+      ],
+      billingProfile: {
+        contactEmail: `${legacyUser.name || "legacy"}@example.com`,
+      },
+      createdAt: created,
+      createdBy: ownerId,
+    };
+
+    const user: UserAccount = {
+      id: ownerId,
+      email: `${legacyUser.name || "legacy"}@example.com`,
+      name: legacyUser.name || "Legacy User",
+      passwordHash: createPasswordHash("changeme"),
+      globalRoles: [],
+      organizations: [{ orgId, roles: ["OWNER", "ADMIN", "BILLING"] }],
+      createdAt: created,
+      status: "active",
+    };
+
+    const store: IdentityStoreData = {
+      users: { [ownerId]: user },
+      organizations: { [orgId]: organization },
+      auditLog: [],
+    };
+
+    await saveIdentity(store);
+    return store;
   } catch {
-    const now = new Date().toISOString();
-    const defaultUser: UserData = {
-      id: DEFAULT_USER_ID,
-      name: "Default User",
-      credits: 0,
-      usage: [],
-      keySets: [
-        {
-          id: uuid(),
-          name: "Default",
-          description: "",
-          keys: [
-            { id: uuid(), key: uuid(), lastRotated: now, usage: [] },
-            { id: uuid(), key: uuid(), lastRotated: now, usage: [] },
-          ],
-        },
-      ],
-    };
-    const users = { [DEFAULT_USER_ID]: defaultUser };
-    await saveUsers(users);
-    return users;
+    return null;
   }
 }
 
-export async function getUsers(): Promise<UserData[]> {
-  const users = await loadUsers();
-  return Object.values(users);
+async function createBootstrapIdentity(): Promise<IdentityStoreData> {
+  const orgId = uuid();
+  const ownerId = uuid();
+  const sysAdminId = uuid();
+  const created = now();
+
+  const owner: UserAccount = {
+    id: ownerId,
+    email: "owner@example.com",
+    name: "Default Org Owner",
+    passwordHash: createPasswordHash("owner"),
+    globalRoles: [],
+    organizations: [{ orgId, roles: ["OWNER", "ADMIN", "BILLING"] }],
+    createdAt: created,
+    status: "active",
+  };
+
+  const sysAdmin: UserAccount = {
+    id: sysAdminId,
+    email: "sysadmin@werobots.dev",
+    name: "WR SysAdmin",
+    passwordHash: createPasswordHash("sysadmin"),
+    globalRoles: ["SYSADMIN"],
+    organizations: [],
+    createdAt: created,
+    status: "active",
+  };
+
+  const organization: Organization = {
+    id: orgId,
+    name: "Default Organization",
+    slug: slugify("Default Organization"),
+    credits: 0,
+    usage: [],
+    keySets: [createDefaultKeySet(ownerId)],
+    members: [
+      {
+        userId: ownerId,
+        roles: ["OWNER", "ADMIN", "BILLING"],
+        invitedAt: created,
+        joinedAt: created,
+        status: "active",
+      },
+    ],
+    billingProfile: {
+      contactEmail: "billing@example.com",
+      contactName: "Default Billing Contact",
+    },
+    createdAt: created,
+    createdBy: ownerId,
+  };
+
+  return {
+    users: {
+      [ownerId]: owner,
+      [sysAdminId]: sysAdmin,
+    },
+    organizations: {
+      [orgId]: organization,
+    },
+    auditLog: [],
+  };
 }
 
-export async function getUser(
-  userId: string = DEFAULT_USER_ID,
-): Promise<UserData> {
-  const users = await loadUsers();
-  let user = users[userId];
-  if (!user) {
-    const now = new Date().toISOString();
-    user = {
-      id: userId,
-      name: userId,
-      credits: 0,
-      usage: [],
-      keySets: [
-        {
-          id: uuid(),
-          name: "Default",
-          description: "",
-          keys: [
-            { id: uuid(), key: uuid(), lastRotated: now, usage: [] },
-            { id: uuid(), key: uuid(), lastRotated: now, usage: [] },
-          ],
-        },
-      ],
-    };
-    users[userId] = user;
-    await saveUsers(users);
-  }
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function maskFromLastFour(lastFour: string): string {
+  return `**** **** **** ${lastFour}`;
+}
+
+function hashApiKey(key: string): string {
+  return crypto.createHmac("sha256", HASH_SECRET).update(key).digest("hex");
+}
+
+function encryptValue(value: string): {
+  encrypted: string;
+  iv: string;
+  authTag: string;
+} {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", deriveEncryptionKey(), iv);
+  const encrypted = Buffer.concat([cipher.update(value, "utf-8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return {
+    encrypted: encrypted.toString("base64"),
+    iv: iv.toString("base64"),
+    authTag: authTag.toString("base64"),
+  };
+}
+
+function decryptValue(
+  encrypted: string,
+  iv: string,
+  authTag: string,
+): string {
+  const decipher = crypto.createDecipheriv(
+    "aes-256-gcm",
+    deriveEncryptionKey(),
+    Buffer.from(iv, "base64"),
+  );
+  decipher.setAuthTag(Buffer.from(authTag, "base64"));
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(encrypted, "base64")),
+    decipher.final(),
+  ]);
+  return decrypted.toString("utf-8");
+}
+
+function createStoredKeyFromPlain(key: string, actorId: string): StoredApiKey {
+  const { encrypted, iv, authTag } = encryptValue(key);
+  const timestamp = now();
+  return {
+    id: uuid(),
+    encryptedKey: encrypted,
+    encryptionIv: iv,
+    encryptionAuthTag: authTag,
+    keyHash: hashApiKey(key),
+    lastFour: key.slice(-4),
+    lastRotated: timestamp,
+    usage: [],
+    createdAt: timestamp,
+    createdBy: actorId,
+  };
+}
+
+function createDefaultKeySet(actorId: string): KeySet {
+  const createdAt = now();
+  const keyA = createStoredKeyFromPlain(generatePlainApiKey(), actorId);
+  const keyB = createStoredKeyFromPlain(generatePlainApiKey(), actorId);
+  return {
+    id: uuid(),
+    name: "Default",
+    description: "Initial key set",
+    keys: [keyA, keyB],
+    createdAt,
+    createdBy: actorId,
+  };
+}
+
+export function generatePlainApiKey(): string {
+  const random = crypto.randomBytes(24).toString("hex");
+  return `wr_${random}`;
+}
+
+export function createPasswordHash(password: string): string {
+  const salt = crypto.randomBytes(16);
+  const hash = crypto.scryptSync(password, salt, 64);
+  return `${salt.toString("hex")}:${hash.toString("hex")}`;
+}
+
+export function verifyPassword(password: string, storedHash: string): boolean {
+  const [saltHex, hashHex] = storedHash.split(":");
+  if (!saltHex || !hashHex) return false;
+  const salt = Buffer.from(saltHex, "hex");
+  const hash = Buffer.from(hashHex, "hex");
+  const derived = crypto.scryptSync(password, salt, hash.length);
+  return crypto.timingSafeEqual(hash, derived);
+}
+
+export async function getIdentityStore(): Promise<IdentityStoreData> {
+  return loadIdentity();
+}
+
+export async function getOrganizations(): Promise<Organization[]> {
+  const store = await loadIdentity();
+  return Object.values(store.organizations);
+}
+
+export async function getOrganization(orgId: string): Promise<Organization | null> {
+  const store = await loadIdentity();
+  return store.organizations[orgId] || null;
+}
+
+export async function getUsersForOrganization(orgId: string): Promise<UserAccount[]> {
+  const store = await loadIdentity();
+  const org = store.organizations[orgId];
+  if (!org) return [];
+  return org.members
+    .map((member) => store.users[member.userId])
+    .filter((u): u is UserAccount => Boolean(u));
+}
+
+export async function getUser(userId: string): Promise<UserAccount | null> {
+  const store = await loadIdentity();
+  return store.users[userId] || null;
+}
+
+export async function getUserByEmail(email: string): Promise<UserAccount | null> {
+  const store = await loadIdentity();
+  return (
+    Object.values(store.users).find(
+      (u) => u.email.toLowerCase() === email.toLowerCase(),
+    ) || null
+  );
+}
+
+export async function createUserAccount(params: {
+  email: string;
+  name: string;
+  password: string;
+  globalRoles?: GlobalRole[];
+}): Promise<UserAccount> {
+  const store = await loadIdentity();
+  const id = uuid();
+  const user: UserAccount = {
+    id,
+    email: params.email,
+    name: params.name,
+    passwordHash: createPasswordHash(params.password),
+    globalRoles: params.globalRoles || [],
+    organizations: [],
+    createdAt: now(),
+    status: "active",
+  };
+  store.users[id] = user;
+  await saveIdentity(store);
   return user;
 }
 
-export async function topUp(
+export async function updateUserLastLogin(userId: string): Promise<void> {
+  const store = await loadIdentity();
+  const user = store.users[userId];
+  if (!user) return;
+  user.lastLoginAt = now();
+  await saveIdentity(store);
+}
+
+export async function createOrganizationWithOwner(params: {
+  organizationName: string;
+  ownerEmail: string;
+  ownerName: string;
+  ownerPassword: string;
+  billingEmail?: string;
+}): Promise<{ organization: Organization; owner: UserAccount; apiKeys: string[] }>
+{
+  const store = await loadIdentity();
+  const existing = await getUserByEmail(params.ownerEmail);
+  if (existing) {
+    throw new Error("User with this email already exists");
+  }
+
+  const orgId = uuid();
+  const ownerId = uuid();
+  const created = now();
+
+  const keySet = createDefaultKeySet(ownerId);
+
+  const owner: UserAccount = {
+    id: ownerId,
+    email: params.ownerEmail,
+    name: params.ownerName,
+    passwordHash: createPasswordHash(params.ownerPassword),
+    globalRoles: [],
+    organizations: [{ orgId, roles: ["OWNER", "ADMIN", "BILLING"] }],
+    createdAt: created,
+    status: "active",
+  };
+
+  const organization: Organization = {
+    id: orgId,
+    name: params.organizationName,
+    slug: slugify(params.organizationName),
+    credits: 0,
+    usage: [],
+    keySets: [keySet],
+    members: [
+      {
+        userId: ownerId,
+        roles: ["OWNER", "ADMIN", "BILLING"],
+        invitedAt: created,
+        joinedAt: created,
+        status: "active",
+      },
+    ],
+    billingProfile: {
+      contactEmail: params.billingEmail || params.ownerEmail,
+      contactName: params.ownerName,
+    },
+    createdAt: created,
+    createdBy: ownerId,
+  };
+
+  store.users[ownerId] = owner;
+  store.organizations[orgId] = organization;
+  await saveIdentity(store);
+
+  const apiKeys = keySet.keys.map((key) => decryptValue(
+    key.encryptedKey,
+    key.encryptionIv,
+    key.encryptionAuthTag,
+  ));
+
+  return { organization, owner, apiKeys };
+}
+
+export async function attachUserToOrganization(params: {
+  userId: string;
+  orgId: string;
+  roles: OrgRole[];
+}): Promise<void> {
+  const store = await loadIdentity();
+  const user = store.users[params.userId];
+  const org = store.organizations[params.orgId];
+  if (!user || !org) throw new Error("User or organization not found");
+
+  if (!user.organizations.some((o) => o.orgId === params.orgId)) {
+    user.organizations.push({ orgId: params.orgId, roles: params.roles });
+  } else {
+    user.organizations = user.organizations.map((o) =>
+      o.orgId === params.orgId ? { orgId: params.orgId, roles: params.roles } : o,
+    );
+  }
+
+  const membership = org.members.find((m) => m.userId === params.userId);
+  if (membership) {
+    membership.roles = params.roles;
+    membership.status = "active";
+  } else {
+    org.members.push({
+      userId: params.userId,
+      roles: params.roles,
+      invitedAt: now(),
+      joinedAt: now(),
+      status: "active",
+    });
+  }
+
+  await saveIdentity(store);
+}
+
+export async function createOrUpdateOrgUser(params: {
+  orgId: string;
+  email: string;
+  name: string;
+  roles: OrgRole[];
+  password?: string;
+}): Promise<{ user: UserAccount; isNewUser: boolean; generatedPassword?: string }>
+{
+  const store = await loadIdentity();
+  const org = store.organizations[params.orgId];
+  if (!org) throw new Error("Organization not found");
+
+  let user = Object.values(store.users).find(
+    (u) => u.email.toLowerCase() === params.email.toLowerCase(),
+  );
+  let generatedPassword: string | undefined;
+  let isNewUser = false;
+  if (!user) {
+    const password = params.password || crypto.randomBytes(8).toString("hex");
+    generatedPassword = params.password ? undefined : password;
+    user = {
+      id: uuid(),
+      email: params.email,
+      name: params.name,
+      passwordHash: createPasswordHash(password),
+      globalRoles: [],
+      organizations: [],
+      createdAt: now(),
+      status: "active",
+    };
+    store.users[user.id] = user;
+    isNewUser = true;
+  } else {
+    user.name = params.name;
+    if (params.password) {
+      user.passwordHash = createPasswordHash(params.password);
+    }
+  }
+
+  if (!user.organizations.some((o) => o.orgId === params.orgId)) {
+    user.organizations.push({ orgId: params.orgId, roles: params.roles });
+  } else {
+    user.organizations = user.organizations.map((o) =>
+      o.orgId === params.orgId ? { orgId: params.orgId, roles: params.roles } : o,
+    );
+  }
+
+  const membership = org.members.find((m) => m.userId === user.id);
+  if (membership) {
+    membership.roles = params.roles;
+    membership.status = "active";
+  } else {
+    org.members.push({
+      userId: user.id,
+      roles: params.roles,
+      invitedAt: now(),
+      joinedAt: now(),
+      status: "active",
+    });
+  }
+
+  await saveIdentity(store);
+
+  return { user, isNewUser, generatedPassword };
+}
+
+export async function topUpOrganization(
+  orgId: string,
   amount: number,
-  userId: string = DEFAULT_USER_ID,
-): Promise<UserData> {
-  const users = await loadUsers();
-  const user = await getUser(userId);
-  user.credits += amount;
+): Promise<Organization> {
+  const store = await loadIdentity();
+  const org = store.organizations[orgId];
+  if (!org) throw new Error("Organization not found");
+  org.credits += amount;
   const entry: UsageEntry = {
-    timestamp: new Date().toISOString(),
+    timestamp: now(),
     action: "topup",
     tokenCost: 0,
     billedCost: -amount,
     requests: 0,
   };
-  user.usage.push(entry);
-  users[userId] = user;
-  await saveUsers(users);
-  return user;
+  org.usage.push(entry);
+  await saveIdentity(store);
+  return org;
 }
 
-export async function recordUsage(
-  tokenCost: number,
-  billedCost: number,
-  action: string,
-  userId: string = DEFAULT_USER_ID,
-  requests: number = 0,
-  keySetId?: string,
-  keyId?: string,
-): Promise<UserData> {
-  const users = await loadUsers();
-  const user = await getUser(userId);
-  user.credits -= billedCost;
+export async function recordUsage(params: {
+  orgId: string;
+  tokenCost: number;
+  billedCost: number;
+  action: string;
+  requests?: number;
+  keySetId?: string;
+  keyId?: string;
+  metadata?: Record<string, unknown>;
+}): Promise<void> {
+  const store = await loadIdentity();
+  const org = store.organizations[params.orgId];
+  if (!org) throw new Error("Organization not found");
+  org.credits -= params.billedCost;
   const entry: UsageEntry = {
-    timestamp: new Date().toISOString(),
-    action,
-    tokenCost,
-    billedCost,
-    requests,
+    timestamp: now(),
+    action: params.action,
+    tokenCost: params.tokenCost,
+    billedCost: params.billedCost,
+    requests: params.requests ?? 0,
+    metadata: params.metadata,
   };
-  user.usage.push(entry);
+  org.usage.push(entry);
 
-  if (keySetId && keyId) {
-    const ks = user.keySets.find((k) => k.id === keySetId);
-    const key = ks?.keys.find((k) => k.id === keyId);
+  if (params.keySetId && params.keyId) {
+    const keySet = org.keySets.find((ks) => ks.id === params.keySetId);
+    const key = keySet?.keys.find((k) => k.id === params.keyId);
     if (key) {
       key.usage.push(entry);
     }
   }
 
-  users[userId] = user;
-  await saveUsers(users);
-  return user;
+  await saveIdentity(store);
+}
+
+export function maskKey(lastFour: string): string {
+  return maskFromLastFour(lastFour);
+}
+
+export function toSafeKey(set: StoredApiKey) {
+  return {
+    id: set.id,
+    maskedKey: maskFromLastFour(set.lastFour),
+    lastFour: set.lastFour,
+    lastRotated: set.lastRotated,
+    usage: set.usage,
+    createdAt: set.createdAt,
+    createdBy: set.createdBy,
+  };
+}
+
+export function toSafeKeySet(set: KeySet) {
+  return {
+    id: set.id,
+    name: set.name,
+    description: set.description,
+    createdAt: set.createdAt,
+    createdBy: set.createdBy,
+    keys: set.keys.map(toSafeKey),
+  };
+}
+
+export function toSafeOrganization(org: Organization) {
+  return {
+    id: org.id,
+    name: org.name,
+    slug: org.slug,
+    credits: org.credits,
+    usage: org.usage,
+    keySets: org.keySets.map(toSafeKeySet),
+    billingProfile: org.billingProfile,
+    members: org.members,
+    createdAt: org.createdAt,
+    createdBy: org.createdBy,
+  };
+}
+
+export function toSafeUser(user: UserAccount) {
+  return {
+    id: user.id,
+    email: user.email,
+    name: user.name,
+    globalRoles: user.globalRoles,
+    organizations: user.organizations,
+    createdAt: user.createdAt,
+    lastLoginAt: user.lastLoginAt,
+    status: user.status,
+  };
 }
 
 export async function addKeySet(
+  orgId: string,
+  actorId: string,
   name: string,
   description: string,
-  userId: string = DEFAULT_USER_ID,
-): Promise<KeySet> {
-  const users = await loadUsers();
-  const user = await getUser(userId);
-  const now = new Date().toISOString();
+): Promise<{ keySet: ReturnType<typeof toSafeKeySet>; revealedKeys: string[] }>
+{
+  const store = await loadIdentity();
+  const org = store.organizations[orgId];
+  if (!org) throw new Error("Organization not found");
+  const createdAt = now();
+  const keyAPlain = generatePlainApiKey();
+  const keyBPlain = generatePlainApiKey();
   const keySet: KeySet = {
     id: uuid(),
     name,
     description,
     keys: [
-      { id: uuid(), key: uuid(), lastRotated: now, usage: [] },
-      { id: uuid(), key: uuid(), lastRotated: now, usage: [] },
+      createStoredKeyFromPlain(keyAPlain, actorId),
+      createStoredKeyFromPlain(keyBPlain, actorId),
     ],
+    createdAt,
+    createdBy: actorId,
   };
-  user.keySets.push(keySet);
-  users[userId] = user;
-  await saveUsers(users);
-  return keySet;
+  org.keySets.push(keySet);
+  await saveIdentity(store);
+  return {
+    keySet: toSafeKeySet(keySet),
+    revealedKeys: [keyAPlain, keyBPlain],
+  };
 }
 
 export async function removeKeySet(
+  orgId: string,
   setId: string,
-  userId: string = DEFAULT_USER_ID,
 ): Promise<void> {
-  const users = await loadUsers();
-  const user = await getUser(userId);
-  user.keySets = user.keySets.filter((ks) => ks.id !== setId);
-  users[userId] = user;
-  await saveUsers(users);
+  const store = await loadIdentity();
+  const org = store.organizations[orgId];
+  if (!org) throw new Error("Organization not found");
+  org.keySets = org.keySets.filter((ks) => ks.id !== setId);
+  await saveIdentity(store);
 }
 
 export async function rotateApiKey(
+  orgId: string,
   setId: string,
   index: number,
-  userId: string = DEFAULT_USER_ID,
-): Promise<string> {
-  const users = await loadUsers();
-  const user = await getUser(userId);
-  const keySet = user.keySets.find((ks) => ks.id === setId);
+  actorId: string,
+): Promise<{ apiKey: string; safeKey: ReturnType<typeof toSafeKey> }>
+{
+  const store = await loadIdentity();
+  const org = store.organizations[orgId];
+  if (!org) throw new Error("Organization not found");
+  const keySet = org.keySets.find((ks) => ks.id === setId);
   if (!keySet) throw new Error("Key set not found");
-  if (index < 0 || index > 1) throw new Error("Invalid key index");
-  const newKey = { id: uuid(), key: uuid(), lastRotated: new Date().toISOString(), usage: [] };
-  keySet.keys[index] = newKey;
-  users[userId] = user;
-  await saveUsers(users);
-  return newKey.key;
+  if (index < 0 || index >= keySet.keys.length) {
+    throw new Error("Invalid key index");
+  }
+  const plain = generatePlainApiKey();
+  const stored = createStoredKeyFromPlain(plain, actorId);
+  keySet.keys[index] = stored;
+  await saveIdentity(store);
+  return { apiKey: plain, safeKey: toSafeKey(stored) };
 }
 
-export async function maskKey(key: string): Promise<string> {
-  return key.replace(/.(?=.{4})/g, "*");
+export async function findOrgByApiKey(
+  apiKey: string,
+): Promise<{
+  organization: Organization;
+  keySet: KeySet;
+  key: StoredApiKey;
+} | null> {
+  const store = await loadIdentity();
+  const hash = hashApiKey(apiKey);
+  for (const org of Object.values(store.organizations)) {
+    for (const keySet of org.keySets) {
+      const key = keySet.keys.find((k) => k.keyHash === hash);
+      if (key) {
+        return { organization: org, keySet, key };
+      }
+    }
+  }
+  return null;
 }
 
+export function revealStoredKey(key: StoredApiKey): string {
+  return decryptValue(key.encryptedKey, key.encryptionIv, key.encryptionAuthTag);
+}

--- a/frontend/components/DynamicWidthTextarea.tsx
+++ b/frontend/components/DynamicWidthTextarea.tsx
@@ -1,6 +1,6 @@
 // components/DynamicWidthTextarea.tsx
 
-import React, { useState, useRef, useLayoutEffect } from "react";
+import React, { useState, useRef, useLayoutEffect, useCallback } from "react";
 
 interface DynamicWidthTextareaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -21,12 +21,12 @@ const DynamicWidthTextarea: React.FC<DynamicWidthTextareaProps> = ({
   const [value, setValue] = useState(String(defaultValue));
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const adjustHeight = () => {
+  const adjustHeight = useCallback(() => {
     if (!props.rows && growVertically && textareaRef.current) {
       textareaRef.current.style.height = "auto";
       textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
     }
-  };
+  }, [growVertically, props.rows]);
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setValue(e.target.value);
@@ -40,7 +40,7 @@ const DynamicWidthTextarea: React.FC<DynamicWidthTextareaProps> = ({
 
   useLayoutEffect(() => {
     adjustHeight();
-  }, [value, growVertically]);
+  }, [adjustHeight, value]);
 
   return (
     <div className={`container${growVertically ? " vertical" : ""}`}>

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -1,0 +1,257 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  ReactNode,
+  useCallback,
+} from "react";
+import {
+  AccountPermissions,
+  SafeOrganization,
+  SafeUser,
+} from "@/types/account";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
+
+interface AuthContextValue {
+  token: string | null;
+  user: SafeUser | null;
+  organization: SafeOrganization | null;
+  organizations: SafeOrganization[];
+  permissions: AccountPermissions | null;
+  activeOrgId: string | null;
+  loading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  signup: (input: {
+    organizationName: string;
+    ownerEmail: string;
+    ownerName: string;
+    ownerPassword: string;
+    billingEmail?: string;
+  }) => Promise<{ revealedApiKeys: string[] }>;
+  logout: () => void;
+  refreshAccount: () => Promise<void>;
+  setActiveOrg: (orgId: string) => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+function getStoredValue(key: string): string | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage.getItem(key);
+}
+
+function setStoredValue(key: string, value: string | null) {
+  if (typeof window === "undefined") return;
+  if (value === null) {
+    window.localStorage.removeItem(key);
+  } else {
+    window.localStorage.setItem(key, value);
+  }
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [token, setToken] = useState<string | null>(null);
+  const [user, setUser] = useState<SafeUser | null>(null);
+  const [organization, setOrganization] = useState<SafeOrganization | null>(null);
+  const [organizations, setOrganizations] = useState<SafeOrganization[]>([]);
+  const [permissions, setPermissions] = useState<AccountPermissions | null>(null);
+  const [activeOrgId, setActiveOrgId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchWithAuth = useCallback(
+    async (
+      path: string,
+      opts: RequestInit = {},
+      orgId?: string | null,
+      customToken?: string | null,
+    ) => {
+      const activeToken = customToken ?? token;
+      if (!activeToken) {
+        throw new Error("No active session");
+      }
+      const headers = new Headers(opts.headers || {});
+      headers.set("Authorization", `Bearer ${activeToken}`);
+      const targetOrg = orgId ?? activeOrgId;
+      if (targetOrg) {
+        headers.set("x-org-id", targetOrg);
+      }
+      const res = await fetch(`${API_URL}${path}`, { ...opts, headers });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || res.statusText);
+      }
+      return res.json();
+    },
+    [token, activeOrgId],
+  );
+
+  const refreshAccountInternal = useCallback(
+    async (customToken?: string | null, orgId?: string) => {
+      const activeToken = customToken ?? token;
+      if (!activeToken) {
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
+      try {
+        const accountData = await fetchWithAuth(
+          "/api/account",
+          {},
+          orgId ?? activeOrgId,
+          activeToken,
+        );
+        setUser(accountData.user);
+        setOrganization(accountData.organization);
+        setPermissions(accountData.permissions);
+        const resolvedOrgId =
+          orgId ?? activeOrgId ?? accountData.organization?.id ?? null;
+        if (resolvedOrgId) {
+          setActiveOrgId(resolvedOrgId);
+          setStoredValue("wr_active_org", resolvedOrgId);
+        }
+        const orgList = await fetchWithAuth(
+          "/api/account/organizations",
+          {},
+          resolvedOrgId,
+          activeToken,
+        );
+        setOrganizations(orgList.organizations || []);
+      } catch (err) {
+        console.error("Failed to refresh account", err);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [token, activeOrgId, fetchWithAuth],
+  );
+
+  const logout = useCallback(() => {
+    setToken(null);
+    setUser(null);
+    setOrganization(null);
+    setOrganizations([]);
+    setPermissions(null);
+    setActiveOrgId(null);
+    setStoredValue("wr_auth_token", null);
+    setStoredValue("wr_active_org", null);
+  }, []);
+
+  useEffect(() => {
+    const storedToken = getStoredValue("wr_auth_token");
+    const storedOrg = getStoredValue("wr_active_org");
+    if (storedToken) {
+      setToken(storedToken);
+      setActiveOrgId(storedOrg);
+      refreshAccountInternal(storedToken, storedOrg ?? undefined).catch(() => {
+        logout();
+      });
+    } else {
+      setLoading(false);
+    }
+  }, [refreshAccountInternal, logout]);
+
+  const login = useCallback(
+    async (email: string, password: string) => {
+      const res = await fetch(`${API_URL}/api/auth/dev/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+      if (!res.ok) {
+        throw new Error(await res.text());
+      }
+      const data = await res.json();
+      setToken(data.token);
+      setStoredValue("wr_auth_token", data.token);
+      const firstOrg = data.organizations?.[0]?.id ?? null;
+      if (firstOrg) {
+        setActiveOrgId(firstOrg);
+        setStoredValue("wr_active_org", firstOrg);
+      }
+      setOrganizations(data.organizations || []);
+      await refreshAccountInternal(data.token, firstOrg ?? undefined);
+    },
+    [refreshAccountInternal],
+  );
+
+  const signup = useCallback(
+    async (input: {
+      organizationName: string;
+      ownerEmail: string;
+      ownerName: string;
+      ownerPassword: string;
+      billingEmail?: string;
+    }): Promise<{ revealedApiKeys: string[] }> => {
+      const res = await fetch(`${API_URL}/api/auth/dev/signup`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      if (!res.ok) {
+        throw new Error(await res.text());
+      }
+      const data = await res.json();
+      setToken(data.token);
+      setStoredValue("wr_auth_token", data.token);
+      setActiveOrgId(data.organization.id);
+      setStoredValue("wr_active_org", data.organization.id);
+      setOrganizations([data.organization]);
+      await refreshAccountInternal(data.token, data.organization.id);
+      return { revealedApiKeys: data.revealedApiKeys || [] };
+    },
+    [refreshAccountInternal],
+  );
+
+  const setActiveOrg = useCallback(
+    async (orgId: string) => {
+      setActiveOrgId(orgId);
+      setStoredValue("wr_active_org", orgId);
+      await refreshAccountInternal(token, orgId);
+    },
+    [refreshAccountInternal, token],
+  );
+
+  const triggerRefresh = useCallback(() => refreshAccountInternal(), [refreshAccountInternal]);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      token,
+      user,
+      organization,
+      organizations,
+      permissions,
+      activeOrgId,
+      loading,
+      login,
+      signup,
+      logout,
+      refreshAccount: triggerRefresh,
+      setActiveOrg,
+    }),
+    [
+      token,
+      user,
+      organization,
+      organizations,
+      permissions,
+      activeOrgId,
+      loading,
+      login,
+      signup,
+      logout,
+      triggerRefresh,
+      setActiveOrg,
+    ],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -7,6 +7,10 @@ export async function fetchJSON<T>(
   if (typeof window !== "undefined") {
     const apiKey = localStorage.getItem("apiKey");
     if (apiKey) headers.set("x-api-key", apiKey);
+    const token = localStorage.getItem("wr_auth_token");
+    if (token) headers.set("Authorization", `Bearer ${token}`);
+    const orgId = localStorage.getItem("wr_active_org");
+    if (orgId) headers.set("x-org-id", orgId);
   }
   const res = await fetch(url, { ...opts, headers });
   if (!res.ok) throw new Error(await res.text());

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -3,8 +3,10 @@ import { AppProps } from "next/app";
 import Link from "next/link";
 import { useState } from "react";
 import ApiKeyModal from "@/components/ApiKeyModal";
+import { AuthProvider, useAuth } from "@/context/AuthContext";
+import { SafeOrganization } from "@/types/account";
 
-export default function MyApp({ Component, pageProps }: AppProps) {
+function InnerApp({ Component, pageProps }: AppProps) {
   const [questionSet, setQuestionSet] = useState<QuestionSet | null>(null);
   const [isSaved, setIsSaved] = useState(false);
   const [snippets, setSnippets] = useState<Record<string, QAResult>>({});
@@ -12,35 +14,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <div className="app-layout">
       <ApiKeyModal />
-      <nav className="app-nav">
-        <div className="nav-links">
-          <Link href="/questions">Questions</Link>
-          {questionSet && (
-            <>
-              {" "}|{" "}
-              <Link href="/snippets">
-                Snippets
-                {Object.keys(snippets).length > 0
-                  ? ` (${Object.keys(snippets).length})`
-                  : ""}
-              </Link>
-            </>
-          )}
-          {questionSet && (
-            <span
-              className="nav-current-set"
-              title={questionSet.title}
-            >
-              {`- ${questionSet.title}`}
-            </span>
-          )}
-        </div>
-        <div className="nav-links">
-          <Link href="/account/billing">Account &amp; Billing</Link>
-          {" "}|{" "}
-          <Link href="/admin/users">Admin</Link>
-        </div>
-      </nav>
+      <Navigation questionSet={questionSet} snippets={snippets} />
       <main className="app-content">
         <Component
           {...pageProps}
@@ -68,7 +42,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
         }
         .app-nav {
           flex: 0 0 auto;
-          height: 40px;
+          height: 48px;
           display: flex;
           align-items: center;
           justify-content: space-between;
@@ -79,9 +53,12 @@ export default function MyApp({ Component, pageProps }: AppProps) {
         .nav-links {
           display: flex;
           align-items: center;
+          gap: 0.75rem;
+        }
+        .nav-links.right {
+          gap: 1rem;
         }
         .app-nav a {
-          margin: 0 0.75rem;
           color: #1890ff;
           text-decoration: none;
           font-weight: 500;
@@ -97,7 +74,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
           overflow-y: auto;
         }
         .nav-current-set {
-          margin-left: 0.75rem;
+          margin-left: 0.25rem;
           max-width: 300px;
           overflow: hidden;
           text-overflow: ellipsis;
@@ -105,7 +82,138 @@ export default function MyApp({ Component, pageProps }: AppProps) {
           color: #555;
           font-size: 0.9rem;
         }
+        .nav-auth {
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+        }
+        .nav-auth select {
+          padding: 0.25rem 0.5rem;
+        }
+        .nav-auth button {
+          padding: 0.25rem 0.75rem;
+          border: none;
+          background: #f5222d;
+          color: #fff;
+          border-radius: 4px;
+          cursor: pointer;
+        }
+        .nav-auth button:hover {
+          background: #cf1322;
+        }
+        .nav-auth .nav-user {
+          font-size: 0.9rem;
+          color: #333;
+        }
       `}</style>
     </div>
+  );
+}
+
+function Navigation({
+  questionSet,
+  snippets,
+}: {
+  questionSet: QuestionSet | null;
+  snippets: Record<string, QAResult>;
+}) {
+  const { user, permissions, organizations, activeOrgId, setActiveOrg, logout, loading } = useAuth();
+  const isSysAdmin = Boolean(user?.globalRoles.includes("SYSADMIN"));
+  return (
+    <nav className="app-nav">
+      <div className="nav-links">
+        <Link href="/questions">Questions</Link>
+        {questionSet && (
+          <>
+            <span>|</span>
+            <Link href="/snippets">
+              Snippets
+              {Object.keys(snippets).length > 0
+                ? ` (${Object.keys(snippets).length})`
+                : ""}
+            </Link>
+            <span className="nav-current-set" title={questionSet.title}>
+              {`- ${questionSet.title}`}
+            </span>
+          </>
+        )}
+      </div>
+      <div className="nav-links right">
+        {user && (permissions?.manageBilling || permissions?.manageKeys) && (
+          <Link href="/account/billing">Account &amp; Billing</Link>
+        )}
+        {isSysAdmin && (
+          <>
+            <span>|</span>
+            <Link href="/admin/users">Admin</Link>
+          </>
+        )}
+        {!user && !loading && (
+          <>
+            <span>|</span>
+            <Link href="/auth/dev-login">Login / Sign up</Link>
+          </>
+        )}
+        <NavAuth
+          userEmail={user?.email || null}
+          organizations={organizations}
+          activeOrgId={activeOrgId}
+          setActiveOrg={setActiveOrg}
+          logout={logout}
+          loading={loading}
+        />
+      </div>
+    </nav>
+  );
+}
+
+function NavAuth({
+  userEmail,
+  organizations,
+  activeOrgId,
+  setActiveOrg,
+  logout,
+  loading,
+}: {
+  userEmail: string | null;
+  organizations: SafeOrganization[];
+  activeOrgId: string | null;
+  setActiveOrg: (orgId: string) => Promise<void>;
+  logout: () => void;
+  loading: boolean;
+}) {
+  if (!userEmail) {
+    if (loading) return <span>Loading...</span>;
+    return null;
+  }
+  return (
+    <div className="nav-auth">
+      {organizations.length > 1 && (
+        <select
+          value={activeOrgId ?? ""}
+          onChange={(e) => {
+            void setActiveOrg(e.target.value);
+          }}
+        >
+          {organizations.map((org) => (
+            <option key={org.id} value={org.id}>
+              {org.name}
+            </option>
+          ))}
+        </select>
+      )}
+      <span className="nav-user">{userEmail}</span>
+      <button type="button" onClick={() => logout()}>
+        Log out
+      </button>
+    </div>
+  );
+}
+
+export default function MyApp(props: AppProps) {
+  return (
+    <AuthProvider>
+      <InnerApp {...props} />
+    </AuthProvider>
   );
 }

--- a/frontend/pages/account/billing.tsx
+++ b/frontend/pages/account/billing.tsx
@@ -1,91 +1,217 @@
-import { useEffect, useState } from "react";
-import UsageBreakdown, { UsageEntry } from "@/components/UsageBreakdown";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import UsageBreakdown from "@/components/UsageBreakdown";
+import { fetchJSON } from "@/lib/api";
+import { OrgRole, SafeApiKey, SafeKeySet, SafeUser, UsageEntry } from "@/types/account";
+import { useAuth } from "@/context/AuthContext";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
-
-type ApiKey = {
-  id: string;
-  key: string;
-  lastRotated: string;
-  usage: UsageEntry[];
-};
-
-type KeySet = {
-  id: string;
-  name: string;
-  description: string;
-  keys: ApiKey[];
-};
-
-type UserData = {
-  credits: number;
-  usage: UsageEntry[];
-  keySets: KeySet[];
-};
 
 type Pricing = {
   questionGeneration: number;
   questionAnswering: number;
 };
 
-const mask = (key: string) => key.replace(/.(?=.{4})/g, "*");
+type MemberInfo = SafeUser & { roles: OrgRole[] };
+
+type KeyReveal = {
+  keys: string[];
+  context: string;
+};
+
+const ROLE_OPTIONS: { label: string; value: OrgRole }[] = [
+  { label: "Owner", value: "OWNER" },
+  { label: "Admin", value: "ADMIN" },
+  { label: "Billing", value: "BILLING" },
+  { label: "Member", value: "MEMBER" },
+];
 
 export default function BillingPage() {
-  const [data, setData] = useState<UserData | null>(null);
-  const [amount, setAmount] = useState<number>(0);
+  const { organization, permissions, refreshAccount, loading } = useAuth();
   const [pricing, setPricing] = useState<Pricing | null>(null);
+  const [amount, setAmount] = useState<number>(0);
   const [newSet, setNewSet] = useState({ name: "", description: "" });
+  const [reveals, setReveals] = useState<KeyReveal | null>(null);
+  const [members, setMembers] = useState<MemberInfo[]>([]);
+  const [memberForm, setMemberForm] = useState({
+    email: "",
+    name: "",
+    roles: ["MEMBER"] as OrgRole[],
+    password: "",
+  });
+  const [memberMessage, setMemberMessage] = useState<string | null>(null);
+  const [memberError, setMemberError] = useState<string | null>(null);
 
-  const load = async () => {
-    const res = await fetch(`${API_URL}/api/account`);
-    const json = await res.json();
-    setData(json);
-  };
+  const canManageKeys = Boolean(permissions?.manageKeys);
+  const canManageBilling = Boolean(permissions?.manageBilling);
+  const canManageUsers = Boolean(permissions?.manageUsers);
+  const canViewMembers = canManageUsers || canManageBilling;
 
   useEffect(() => {
-    load();
     fetch(`${API_URL}/api/pricing`)
-      .then((r) => r.json())
-      .then(setPricing);
+      .then((res) => res.json())
+      .then(setPricing)
+      .catch(() => setPricing(null));
   }, []);
 
-  const topUp = async () => {
-    await fetch(`${API_URL}/api/account/topup`, {
+  const loadMembers = useCallback(async () => {
+    if (!canViewMembers) return;
+    setMemberError(null);
+    try {
+      const response = await fetchJSON<{ members: MemberInfo[] }>(
+        `${API_URL}/api/account/users`,
+      );
+      setMembers(response.members);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      setMemberError(message || "Failed to load members");
+    }
+  }, [canViewMembers]);
+
+  useEffect(() => {
+    if (!organization) return;
+    void loadMembers();
+  }, [organization, loadMembers]);
+
+  useEffect(() => {
+    if (!organization && !loading) {
+      void refreshAccount();
+    }
+  }, [organization, loading, refreshAccount]);
+
+  const handleTopUp = async () => {
+    if (!canManageBilling || amount <= 0) return;
+    await fetchJSON(`${API_URL}/api/account/topup`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ amount }),
     });
     setAmount(0);
-    load();
+    setReveals(null);
+    await refreshAccount();
   };
 
-  const rotate = async (setId: string, index: number) => {
-    await fetch(`${API_URL}/api/account/keysets/${setId}/keys/${index}/rotate`, {
+  const handleRotate = async (setId: string, index: number) => {
+    if (!canManageKeys) return;
+    const result = await fetchJSON<{
+      apiKey: string;
+      key: SafeApiKey;
+    }>(`${API_URL}/api/account/keysets/${setId}/keys/${index}/rotate`, {
       method: "POST",
     });
-    load();
+    setReveals({
+      keys: [result.apiKey],
+      context: "Rotated API key. Store this new value securely.",
+    });
+    await refreshAccount();
   };
 
-  const addKeySet = async () => {
-    await fetch(`${API_URL}/api/account/keysets`, {
+  const handleAddKeySet = async () => {
+    if (!canManageKeys || !newSet.name) return;
+    const result = await fetchJSON<{
+      keySet: SafeKeySet;
+      revealedKeys: string[];
+    }>(`${API_URL}/api/account/keysets`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(newSet),
     });
     setNewSet({ name: "", description: "" });
-    load();
+    setReveals({
+      keys: result.revealedKeys,
+      context: `Key set "${result.keySet.name}" created. Share these keys only with trusted clients.`,
+    });
+    await refreshAccount();
   };
 
-  const removeSet = async (id: string) => {
-    await fetch(`${API_URL}/api/account/keysets/${id}`, { method: "DELETE" });
-    load();
+  const handleRemoveKeySet = async (id: string) => {
+    if (!canManageKeys) return;
+    await fetchJSON(`${API_URL}/api/account/keysets/${id}`, { method: "DELETE" });
+    await refreshAccount();
   };
 
-  if (!data) return <div>Loading...</div>;
+  const toggleRole = (role: OrgRole) => {
+    setMemberForm((current) => {
+      const hasRole = current.roles.includes(role);
+      const roles = hasRole
+        ? current.roles.filter((r) => r !== role)
+        : [...current.roles, role];
+      return { ...current, roles };
+    });
+  };
+
+  const handleCreateMember = async () => {
+    if (!canManageUsers) return;
+    if (!memberForm.email || !memberForm.name) {
+      setMemberError("Name and email are required");
+      return;
+    }
+    if (!memberForm.roles.length) {
+      setMemberError("Select at least one role");
+      return;
+    }
+    setMemberError(null);
+    setMemberMessage(null);
+    const response = await fetchJSON<{
+      user: MemberInfo;
+      generatedPassword?: string;
+      isNewUser: boolean;
+    }>(`${API_URL}/api/account/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: memberForm.email,
+        name: memberForm.name,
+        roles: memberForm.roles,
+        password: memberForm.password || undefined,
+      }),
+    });
+    setMemberForm({ email: "", name: "", roles: ["MEMBER"], password: "" });
+    await loadMembers();
+    if (response.generatedPassword) {
+      setMemberMessage(
+        `Generated password for ${response.user.email}: ${response.generatedPassword}. Share securely with the user.`,
+      );
+    } else {
+      setMemberMessage("User saved. They can now access the organization.");
+    }
+  };
+
+  const organizationUsage = useMemo<UsageEntry[]>(
+    () => organization?.usage ?? [],
+    [organization?.usage],
+  );
+
+  if (loading && !organization) {
+    return <div className="container">Loading...</div>;
+  }
+
+  if (!organization) {
+    return (
+      <div className="container">
+        <div className="card">
+          <h1>Account &amp; Billing</h1>
+          <p>Please sign in to manage billing and API access.</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="container">
-      <h1>Usage &amp; Billing</h1>
+      <h1>{organization.name} &mdash; Usage &amp; Billing</h1>
+      {reveals && (
+        <div className="card warning">
+          <h2>New credentials</h2>
+          <p>{reveals.context}</p>
+          <ul>
+            {reveals.keys.map((key) => (
+              <li key={key}>
+                <code>{key}</code>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
       {pricing && (
         <div className="card">
           <h2>Pricing</h2>
@@ -100,25 +226,39 @@ export default function BillingPage() {
         </div>
       )}
       <div className="card">
-        <p>Credits: {data.credits.toFixed(2)}</p>
-        <div className="topup">
-          <input
-            type="number"
-            value={amount}
-            onChange={(e) => setAmount(Number(e.target.value))}
-            placeholder="Amount"
-          />
-          <button onClick={topUp}>Top Up</button>
-        </div>
+        <h2>Credits</h2>
+        <p className="metric">${organization.credits.toFixed(2)}</p>
+        {canManageBilling && (
+          <div className="topup">
+            <input
+              type="number"
+              value={amount}
+              onChange={(e) => {
+                const value = Number(e.target.value);
+                setAmount(Number.isNaN(value) ? 0 : value);
+              }}
+              placeholder="Amount"
+              min={0}
+            />
+            <button onClick={handleTopUp} disabled={amount <= 0}>
+              Top Up
+            </button>
+          </div>
+        )}
       </div>
 
       <div className="card">
         <h2>API Key Sets</h2>
-        {data.keySets.map((set) => (
+        {organization.keySets.map((set) => (
           <div key={set.id} className="keyset">
             <div className="keyset-header">
-              <h3>{set.name}</h3>
-              <button onClick={() => removeSet(set.id)}>Remove</button>
+              <div>
+                <h3>{set.name}</h3>
+                <p className="meta">Created {new Date(set.createdAt).toLocaleString()}</p>
+              </div>
+              {canManageKeys && (
+                <button onClick={() => handleRemoveKeySet(set.id)}>Remove</button>
+              )}
             </div>
             <p>{set.description}</p>
             <ul>
@@ -128,15 +268,19 @@ export default function BillingPage() {
                 return (
                   <li key={k.id}>
                     <div className="key-info">
-                      <code>{mask(k.key)}</code>
+                      <code>{k.maskedKey}</code>
                       <span className="rotated">
                         rotated {new Date(k.lastRotated).toLocaleString()}
                       </span>
                     </div>
                     <div className="key-actions">
-                      <button onClick={() => rotate(set.id, idx)}>Rotate</button>
+                      {canManageKeys && (
+                        <button onClick={() => handleRotate(set.id, idx)}>
+                          Rotate
+                        </button>
+                      )}
                       <span className="usage">
-                        {reqs} reqs / {total.toFixed(2)}
+                        {reqs} reqs / {total.toFixed(2)} billed
                       </span>
                     </div>
                   </li>
@@ -145,29 +289,118 @@ export default function BillingPage() {
             </ul>
           </div>
         ))}
-        <div className="add-set">
-          <input
-            type="text"
-            placeholder="Name"
-            value={newSet.name}
-            onChange={(e) => setNewSet({ ...newSet, name: e.target.value })}
-          />
-          <input
-            type="text"
-            placeholder="Description"
-            value={newSet.description}
-            onChange={(e) =>
-              setNewSet({ ...newSet, description: e.target.value })
-            }
-          />
-          <button onClick={addKeySet}>Add Key Set</button>
-        </div>
+        {canManageKeys && (
+          <div className="add-set">
+            <input
+              type="text"
+              placeholder="Name"
+              value={newSet.name}
+              onChange={(e) => setNewSet({ ...newSet, name: e.target.value })}
+            />
+            <input
+              type="text"
+              placeholder="Description"
+              value={newSet.description}
+              onChange={(e) =>
+                setNewSet({ ...newSet, description: e.target.value })
+              }
+            />
+            <button onClick={handleAddKeySet} disabled={!newSet.name}>
+              Add Key Set
+            </button>
+          </div>
+        )}
       </div>
 
       <div className="card">
         <h2>Usage</h2>
-        <UsageBreakdown entries={data.usage} />
+        <UsageBreakdown entries={organizationUsage} />
       </div>
+
+      {canViewMembers && (
+        <div className="card">
+          <h2>Organization members</h2>
+          {memberMessage && <div className="notice success">{memberMessage}</div>}
+          {memberError && <div className="notice error">{memberError}</div>}
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Roles</th>
+                <th>Last login</th>
+              </tr>
+            </thead>
+            <tbody>
+              {members.map((member) => (
+                <tr key={member.id}>
+                  <td>{member.name}</td>
+                  <td>{member.email}</td>
+                  <td>{member.roles.join(", ")}</td>
+                  <td>
+                    {member.lastLoginAt
+                      ? new Date(member.lastLoginAt).toLocaleString()
+                      : "Never"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {canManageUsers && (
+            <div className="member-form">
+              <h3>Add or update member</h3>
+              <div className="form-grid">
+                <label>
+                  Name
+                  <input
+                    type="text"
+                    value={memberForm.name}
+                    onChange={(e) =>
+                      setMemberForm({ ...memberForm, name: e.target.value })
+                    }
+                  />
+                </label>
+                <label>
+                  Email
+                  <input
+                    type="email"
+                    value={memberForm.email}
+                    onChange={(e) =>
+                      setMemberForm({ ...memberForm, email: e.target.value })
+                    }
+                  />
+                </label>
+                <label>
+                  Temporary password (optional)
+                  <input
+                    type="text"
+                    value={memberForm.password}
+                    onChange={(e) =>
+                      setMemberForm({ ...memberForm, password: e.target.value })
+                    }
+                  />
+                </label>
+              </div>
+              <fieldset>
+                <legend>Roles</legend>
+                <div className="role-grid">
+                  {ROLE_OPTIONS.map((role) => (
+                    <label key={role.value}>
+                      <input
+                        type="checkbox"
+                        checked={memberForm.roles.includes(role.value)}
+                        onChange={() => toggleRole(role.value)}
+                      />
+                      {role.label}
+                    </label>
+                  ))}
+                </div>
+              </fieldset>
+              <button onClick={handleCreateMember}>Save member</button>
+            </div>
+          )}
+        </div>
+      )}
 
       <style jsx>{`
         .container {
@@ -183,6 +416,53 @@ export default function BillingPage() {
           padding: 1rem;
           border-radius: 4px;
           box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+          display: flex;
+          flex-direction: column;
+          gap: 0.75rem;
+        }
+        .card.warning {
+          border-left: 4px solid #faad14;
+        }
+        .card.warning ul {
+          list-style: none;
+          margin: 0;
+          padding: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 0.5rem;
+        }
+        .card.warning code {
+          background: #000;
+          color: #fff;
+          padding: 0.25rem 0.5rem;
+          border-radius: 4px;
+          display: inline-block;
+        }
+        .metric {
+          font-size: 2rem;
+          font-weight: 600;
+        }
+        .topup {
+          display: flex;
+          gap: 0.5rem;
+          align-items: center;
+        }
+        .topup input {
+          padding: 0.5rem;
+          border: 1px solid #d9d9d9;
+          border-radius: 4px;
+        }
+        .topup button {
+          padding: 0.5rem 1rem;
+          border: none;
+          border-radius: 4px;
+          background: #1890ff;
+          color: #fff;
+          cursor: pointer;
+        }
+        .topup button:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
         }
         .keyset {
           border-top: 1px solid #eee;
@@ -197,33 +477,12 @@ export default function BillingPage() {
         .key-info {
           display: flex;
           flex-direction: column;
-        }
-        .key-actions {
-          display: flex;
-          align-items: center;
-          gap: 0.5rem;
-        }
-        .rotated {
-          font-size: 0.8rem;
-          color: #666;
-        }
-        .usage {
-          font-size: 0.8rem;
-          color: #333;
-        }
-        .add-set {
-          display: flex;
-          gap: 0.5rem;
-          margin-top: 1rem;
-        }
-        .topup {
-          display: flex;
-          gap: 0.5rem;
-          margin-top: 0.5rem;
+          gap: 0.25rem;
         }
         ul {
           list-style: none;
           padding: 0;
+          margin: 0;
         }
         li {
           display: flex;
@@ -231,12 +490,89 @@ export default function BillingPage() {
           align-items: center;
           padding: 0.25rem 0;
         }
-        input {
-          padding: 0.5rem;
-          flex: 1;
+        .key-actions {
+          display: flex;
+          flex-direction: column;
+          align-items: flex-end;
+          gap: 0.25rem;
         }
-        button {
+        .key-actions button {
+          padding: 0.25rem 0.5rem;
+        }
+        .usage {
+          font-size: 0.85rem;
+          color: #555;
+        }
+        .rotated {
+          font-size: 0.75rem;
+          color: #777;
+        }
+        .add-set {
+          display: flex;
+          gap: 0.5rem;
+          flex-wrap: wrap;
+        }
+        .add-set input {
+          padding: 0.5rem;
+          border: 1px solid #d9d9d9;
+          border-radius: 4px;
+        }
+        .add-set button {
           padding: 0.5rem 1rem;
+          border: none;
+          border-radius: 4px;
+          background: #1890ff;
+          color: #fff;
+          cursor: pointer;
+        }
+        table {
+          width: 100%;
+          border-collapse: collapse;
+        }
+        th,
+        td {
+          text-align: left;
+          padding: 0.5rem;
+          border-bottom: 1px solid #f0f0f0;
+        }
+        .member-form {
+          display: flex;
+          flex-direction: column;
+          gap: 0.75rem;
+          border-top: 1px solid #eee;
+          padding-top: 1rem;
+        }
+        .form-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+          gap: 0.75rem;
+        }
+        .form-grid input {
+          padding: 0.5rem;
+          border: 1px solid #d9d9d9;
+          border-radius: 4px;
+        }
+        fieldset {
+          border: 1px solid #d9d9d9;
+          border-radius: 4px;
+          padding: 0.75rem;
+        }
+        .role-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+          gap: 0.5rem;
+        }
+        .notice {
+          padding: 0.75rem;
+          border-radius: 4px;
+        }
+        .notice.success {
+          background: #f6ffed;
+          border: 1px solid #b7eb8f;
+        }
+        .notice.error {
+          background: #fff2f0;
+          border: 1px solid #ffccc7;
         }
       `}</style>
     </div>

--- a/frontend/pages/admin/users.tsx
+++ b/frontend/pages/admin/users.tsx
@@ -1,125 +1,117 @@
 import { useEffect, useState } from "react";
-import UsageBreakdown, { UsageEntry } from "@/components/UsageBreakdown";
+import UsageBreakdown from "@/components/UsageBreakdown";
+import { fetchJSON } from "@/lib/api";
+import {
+  SafeApiKey,
+  SafeKeySet,
+  SafeOrganization,
+  UsageEntry,
+} from "@/types/account";
+import { useAuth } from "@/context/AuthContext";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
 
-type ApiKey = {
-  id: string;
-  key: string;
-  lastRotated: string;
-  usage: UsageEntry[];
+type KeyReveal = {
+  keys: string[];
+  context: string;
 };
 
-type KeySet = {
-  id: string;
-  name: string;
-  description: string;
-  keys: ApiKey[];
+type AdminOrganization = SafeOrganization;
+
+type OrganizationResponse = {
+  organizations: AdminOrganization[];
 };
 
-type User = {
-  id: string;
-  name: string;
-  credits: number;
-  usage: UsageEntry[];
-  keySets: KeySet[];
+type RotateResponse = {
+  apiKey: string;
+  key: SafeApiKey;
 };
 
-const mask = (key: string) => key.replace(/.(?=.{4})/g, "*");
+export default function AdminOrganizations() {
+  const { user, loading } = useAuth();
+  const [organizations, setOrganizations] = useState<AdminOrganization[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [reveal, setReveal] = useState<KeyReveal | null>(null);
 
-export default function AdminUsers() {
-  const [users, setUsers] = useState<User[]>([]);
-
-  const load = async () => {
-    const res = await fetch(`${API_URL}/api/admin/users`);
-    const json = await res.json();
-    setUsers(json);
-  };
+  const isSysAdmin = Boolean(user?.globalRoles.includes("SYSADMIN"));
 
   useEffect(() => {
-    load();
-  }, []);
+    if (!isSysAdmin) return;
+    fetchJSON<OrganizationResponse>(`${API_URL}/api/admin/organizations`)
+      .then((data) => setOrganizations(data.organizations))
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message || "Failed to load organizations");
+      });
+  }, [isSysAdmin]);
 
-  const rotate = async (userId: string, setId: string, index: number) => {
-    await fetch(
-      `${API_URL}/api/admin/users/${userId}/keysets/${setId}/keys/${index}/rotate`,
+  const rotate = async (orgId: string, setId: string, index: number) => {
+    const result = await fetchJSON<RotateResponse>(
+      `${API_URL}/api/admin/organizations/${orgId}/keysets/${setId}/keys/${index}/rotate`,
       { method: "POST" },
     );
-    load();
+    setReveal({
+      keys: [result.apiKey],
+      context: `Rotated key for organization ${orgId}. Share securely with the client.`,
+    });
+    const refreshed = await fetchJSON<OrganizationResponse>(
+      `${API_URL}/api/admin/organizations`,
+    );
+    setOrganizations(refreshed.organizations);
   };
 
+  if (!isSysAdmin) {
+    return (
+      <div className="admin-container">
+        <div className="card">
+          <h1>Admin dashboard</h1>
+          {loading ? <p>Loading user session...</p> : <p>Sysadmin access required.</p>}
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="container">
-      <h1>Users</h1>
-      {users.map((u) => (
-        <div key={u.id} className="user-card">
+    <div className="admin-container">
+      <h1>Organizations</h1>
+      {error && <div className="notice error">{error}</div>}
+      {reveal && (
+        <div className="notice warning">
+          <strong>New API key</strong>
+          <p>{reveal.context}</p>
+          <ul>
+            {reveal.keys.map((key) => (
+              <li key={key}>
+                <code>{key}</code>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {organizations.map((org) => (
+        <div key={org.id} className="card">
           <h2>
-            {u.name} - {u.credits.toFixed(2)} credits
+            {org.name} &mdash; ${org.credits.toFixed(2)} credits
           </h2>
-          {(() => {
-            const usage = u.usage.filter((e) => e.action !== "topup");
-            const totalRequests = usage.reduce((a, b) => a + b.requests, 0);
-            const totalBilled = usage.reduce((a, b) => a + b.billedCost, 0);
-            const totalCost = usage.reduce((a, b) => a + b.tokenCost, 0);
-            return (
-              <p className="summary">
-                {totalRequests} reqs / billed {totalBilled.toFixed(2)} / cost
-                {" "}
-                {totalCost.toFixed(2)} / profit {(totalBilled - totalCost).toFixed(2)}
-              </p>
-            );
-          })()}
           <div className="keysets">
-            {u.keySets.map((ks) => (
+            {org.keySets.map((ks) => (
               <div key={ks.id} className="keyset">
                 <h3>{ks.name}</h3>
                 <p>{ks.description}</p>
                 <ul>
-                  {ks.keys.map((k, idx) => (
-                    <li key={k.id}>
-                      <div className="key-info">
-                        <code>{mask(k.key)}</code>
-                        <span>
-                          rotated {new Date(k.lastRotated).toLocaleString()}
-                        </span>
-                      </div>
-                      <div className="key-actions">
-                        <button onClick={() => rotate(u.id, ks.id, idx)}>
-                          Rotate
-                        </button>
-                        {(() => {
-                          const reqs = k.usage.reduce((a, b) => a + b.requests, 0);
-                          const billed = k.usage.reduce(
-                            (a, b) => a + b.billedCost,
-                            0,
-                          );
-                          const cost = k.usage.reduce(
-                            (a, b) => a + b.tokenCost,
-                            0,
-                          );
-                          return (
-                            <span className="usage">
-                              {reqs} reqs / billed {billed.toFixed(2)} / cost
-                              {" "}
-                              {cost.toFixed(2)} / profit {(billed - cost).toFixed(2)}
-                            </span>
-                          );
-                        })()}
-                      </div>
-                    </li>
-                  ))}
+                  {ks.keys.map((k, idx) => renderKey(org.id, ks, k, idx, rotate))}
                 </ul>
               </div>
             ))}
           </div>
           <div className="usage">
             <h3>Usage</h3>
-            <UsageBreakdown entries={u.usage} />
+            <UsageBreakdown entries={org.usage.filter(filterTopups)} />
           </div>
         </div>
       ))}
       <style jsx>{`
-        .container {
+        .admin-container {
           padding: 1rem;
           background: #f0f2f5;
           flex: 1 1 auto;
@@ -127,30 +119,35 @@ export default function AdminUsers() {
           flex-direction: column;
           gap: 1rem;
         }
-        .user-card {
+        .card {
           background: #fff;
           padding: 1rem;
           border-radius: 4px;
           box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+          display: flex;
+          flex-direction: column;
+          gap: 0.75rem;
         }
         .keyset {
           border-top: 1px solid #eee;
           margin-top: 0.5rem;
           padding-top: 0.5rem;
         }
-        .key-info {
-          display: flex;
-          flex-direction: column;
-        }
-        ul {
+        .keysets ul {
           list-style: none;
           padding: 0;
+          margin: 0;
         }
-        li {
+        .keysets li {
           display: flex;
           justify-content: space-between;
           align-items: center;
           padding: 0.25rem 0;
+        }
+        .key-info {
+          display: flex;
+          flex-direction: column;
+          gap: 0.25rem;
         }
         .key-actions {
           display: flex;
@@ -158,8 +155,11 @@ export default function AdminUsers() {
           align-items: flex-end;
           gap: 0.25rem;
         }
+        .key-actions button {
+          padding: 0.25rem 0.5rem;
+        }
         .usage {
-          font-size: 0.8rem;
+          font-size: 0.9rem;
         }
         .summary {
           font-size: 0.9rem;
@@ -168,8 +168,65 @@ export default function AdminUsers() {
         button {
           padding: 0.25rem 0.5rem;
         }
+        .notice {
+          padding: 0.75rem;
+          border-radius: 4px;
+        }
+        .notice.error {
+          background: #fff2f0;
+          border: 1px solid #ffccc7;
+        }
+        .notice.warning {
+          background: #fff7e6;
+          border: 1px solid #ffd591;
+        }
+        .notice.warning ul {
+          list-style: none;
+          margin: 0.5rem 0 0;
+          padding: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 0.25rem;
+        }
+        .notice.warning code {
+          background: #000;
+          color: #fff;
+          padding: 0.25rem 0.5rem;
+          border-radius: 4px;
+          display: inline-block;
+        }
       `}</style>
     </div>
   );
 }
 
+function renderKey(
+  orgId: string,
+  set: SafeKeySet,
+  key: SafeApiKey,
+  index: number,
+  rotate: (orgId: string, setId: string, index: number) => Promise<void>,
+) {
+  const reqs = key.usage.reduce((a, b) => a + b.requests, 0);
+  const billed = key.usage.reduce((a, b) => a + b.billedCost, 0);
+  return (
+    <li key={key.id}>
+      <div className="key-info">
+        <code>{key.maskedKey}</code>
+        <span>
+          rotated {new Date(key.lastRotated).toLocaleString()}
+        </span>
+      </div>
+      <div className="key-actions">
+        <button onClick={() => rotate(orgId, set.id, index)}>Rotate</button>
+        <span className="summary">
+          {reqs} reqs / billed {billed.toFixed(2)}
+        </span>
+      </div>
+    </li>
+  );
+}
+
+function filterTopups(entry: UsageEntry) {
+  return entry.action !== "topup";
+}

--- a/frontend/pages/auth/dev-login.tsx
+++ b/frontend/pages/auth/dev-login.tsx
@@ -1,0 +1,275 @@
+import { FormEvent, useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { useAuth } from "@/context/AuthContext";
+
+export default function DevAuthPage() {
+  const { login, signup, user, loading } = useAuth();
+  const router = useRouter();
+  const [loginForm, setLoginForm] = useState({ email: "", password: "" });
+  const [signupForm, setSignupForm] = useState({
+    organizationName: "",
+    ownerEmail: "",
+    ownerName: "",
+    ownerPassword: "",
+    billingEmail: "",
+  });
+  const [revealedKeys, setRevealedKeys] = useState<string[] | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (user && !loading) {
+      router.replace("/account/billing");
+    }
+  }, [user, loading, router]);
+
+  const handleLogin = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setMessage(null);
+    setRevealedKeys(null);
+    setSubmitting(true);
+    try {
+      await login(loginForm.email, loginForm.password);
+      setMessage("Logged in successfully.");
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message || "Failed to login");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleSignup = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setMessage(null);
+    setSubmitting(true);
+    try {
+      const result = await signup({
+        organizationName: signupForm.organizationName,
+        ownerEmail: signupForm.ownerEmail,
+        ownerName: signupForm.ownerName,
+        ownerPassword: signupForm.ownerPassword,
+        billingEmail: signupForm.billingEmail || undefined,
+      });
+      setRevealedKeys(result.revealedApiKeys);
+      setMessage(
+        "Organization created. Copy the API keys now—they will not be shown again.",
+      );
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message || "Failed to sign up");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="auth-container">
+      <div className="card">
+        <h1>Developer Authentication</h1>
+        <p>
+          This local-only auth flow mimics the Keycloak integration we will ship
+          later. The forms below let you create an organization and owner account
+          or sign in with existing credentials.
+        </p>
+        {message && <div className="notice success">{message}</div>}
+        {error && <div className="notice error">{error}</div>}
+        {revealedKeys && revealedKeys.length > 0 && (
+          <div className="notice warning">
+            <strong>New API keys</strong>
+            <p>Copy these values now. They will not be displayed again.</p>
+            <ul>
+              {revealedKeys.map((key) => (
+                <li key={key}>
+                  <code>{key}</code>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        <div className="forms">
+          <form onSubmit={handleLogin} className="panel">
+            <h2>Log in</h2>
+            <label>
+              Email
+              <input
+                type="email"
+                value={loginForm.email}
+                onChange={(e) => setLoginForm({ ...loginForm, email: e.target.value })}
+                required
+              />
+            </label>
+            <label>
+              Password
+              <input
+                type="password"
+                value={loginForm.password}
+                onChange={(e) =>
+                  setLoginForm({ ...loginForm, password: e.target.value })
+                }
+                required
+              />
+            </label>
+            <button type="submit" disabled={submitting}>
+              {submitting ? "Working..." : "Log in"}
+            </button>
+          </form>
+          <form onSubmit={handleSignup} className="panel">
+            <h2>Create organization</h2>
+            <label>
+              Organization name
+              <input
+                type="text"
+                value={signupForm.organizationName}
+                onChange={(e) =>
+                  setSignupForm({ ...signupForm, organizationName: e.target.value })
+                }
+                required
+              />
+            </label>
+            <label>
+              Owner name
+              <input
+                type="text"
+                value={signupForm.ownerName}
+                onChange={(e) =>
+                  setSignupForm({ ...signupForm, ownerName: e.target.value })
+                }
+                required
+              />
+            </label>
+            <label>
+              Owner email
+              <input
+                type="email"
+                value={signupForm.ownerEmail}
+                onChange={(e) =>
+                  setSignupForm({ ...signupForm, ownerEmail: e.target.value })
+                }
+                required
+              />
+            </label>
+            <label>
+              Owner password
+              <input
+                type="password"
+                value={signupForm.ownerPassword}
+                onChange={(e) =>
+                  setSignupForm({ ...signupForm, ownerPassword: e.target.value })
+                }
+                required
+              />
+            </label>
+            <label>
+              Billing email (optional)
+              <input
+                type="email"
+                value={signupForm.billingEmail}
+                onChange={(e) =>
+                  setSignupForm({ ...signupForm, billingEmail: e.target.value })
+                }
+              />
+            </label>
+            <button type="submit" disabled={submitting}>
+              {submitting ? "Working..." : "Create organization"}
+            </button>
+          </form>
+        </div>
+      </div>
+      <style jsx>{`
+        .auth-container {
+          display: flex;
+          justify-content: center;
+          align-items: flex-start;
+          padding: 2rem;
+          background: #f0f2f5;
+          min-height: calc(100vh - 48px);
+        }
+        .card {
+          background: #fff;
+          padding: 2rem;
+          border-radius: 8px;
+          box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+          max-width: 960px;
+          width: 100%;
+          display: flex;
+          flex-direction: column;
+          gap: 1rem;
+        }
+        .forms {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+          gap: 1.5rem;
+        }
+        .panel {
+          display: flex;
+          flex-direction: column;
+          gap: 0.75rem;
+          padding: 1rem;
+          border: 1px solid #e6e6e6;
+          border-radius: 6px;
+          background: #fafafa;
+        }
+        label {
+          display: flex;
+          flex-direction: column;
+          font-weight: 500;
+          font-size: 0.9rem;
+          gap: 0.25rem;
+        }
+        input {
+          padding: 0.5rem;
+          border: 1px solid #d9d9d9;
+          border-radius: 4px;
+          font-size: 1rem;
+        }
+        button {
+          padding: 0.5rem 1rem;
+          border: none;
+          border-radius: 4px;
+          background: #1890ff;
+          color: #fff;
+          cursor: pointer;
+        }
+        button:disabled {
+          opacity: 0.6;
+          cursor: not-allowed;
+        }
+        .notice {
+          padding: 0.75rem;
+          border-radius: 4px;
+        }
+        .notice.success {
+          background: #f6ffed;
+          border: 1px solid #b7eb8f;
+        }
+        .notice.error {
+          background: #fff2f0;
+          border: 1px solid #ffccc7;
+        }
+        .notice.warning {
+          background: #fff7e6;
+          border: 1px solid #ffd591;
+        }
+        .notice.warning ul {
+          margin: 0.5rem 0 0;
+          padding: 0;
+          list-style: none;
+          display: flex;
+          flex-direction: column;
+          gap: 0.25rem;
+        }
+        .notice.warning code {
+          background: #000;
+          color: #fff;
+          padding: 0.25rem 0.5rem;
+          border-radius: 4px;
+          display: inline-block;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -5,6 +5,6 @@ export default function Home() {
   const router = useRouter();
   useEffect(() => {
     router.replace("/questions");
-  }, []);
+  }, [router]);
   return null;
 }

--- a/frontend/types/account.ts
+++ b/frontend/types/account.ts
@@ -1,0 +1,74 @@
+export type OrgRole = "OWNER" | "ADMIN" | "BILLING" | "MEMBER";
+
+export type UsageEntry = {
+  timestamp: string;
+  action: string;
+  tokenCost: number;
+  billedCost: number;
+  requests: number;
+  metadata?: Record<string, unknown>;
+};
+
+export type SafeApiKey = {
+  id: string;
+  maskedKey: string;
+  lastFour: string;
+  lastRotated: string;
+  usage: UsageEntry[];
+  createdAt: string;
+  createdBy: string;
+};
+
+export type SafeKeySet = {
+  id: string;
+  name: string;
+  description: string;
+  keys: SafeApiKey[];
+  createdAt: string;
+  createdBy: string;
+};
+
+export type BillingProfile = {
+  contactEmail: string;
+  contactName?: string;
+  stripeCustomerId?: string | null;
+  notes?: string;
+};
+
+export type OrgMember = {
+  userId: string;
+  roles: OrgRole[];
+  invitedAt: string;
+  joinedAt: string;
+  status: "active" | "invited" | "suspended";
+};
+
+export type SafeOrganization = {
+  id: string;
+  name: string;
+  slug: string;
+  credits: number;
+  usage: UsageEntry[];
+  keySets: SafeKeySet[];
+  billingProfile: BillingProfile;
+  members: OrgMember[];
+  createdAt: string;
+  createdBy: string;
+};
+
+export type SafeUser = {
+  id: string;
+  email: string;
+  name: string;
+  globalRoles: string[];
+  organizations: { orgId: string; roles: OrgRole[] }[];
+  createdAt: string;
+  lastLoginAt?: string;
+  status: "active" | "disabled";
+};
+
+export type AccountPermissions = {
+  manageBilling: boolean;
+  manageKeys: boolean;
+  manageUsers: boolean;
+};


### PR DESCRIPTION
## Summary
- replace the legacy single-user store with an identity layer that models organizations, members, encrypted API keys, and usage tracking
- add development auth endpoints, bearer middleware, and admin/account routes so org owners can manage keys, billing, and members while WR staff can rotate keys across tenants
- wire a React auth context, login/signup screen, and updated account/admin dashboards that surface the new workflows and show rotated keys once for safe storage

## Testing
- npm run test (backend)
- npm run lint (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68c93e548bd88330a2b571d745eec5c0