### PR TITLE
Handle auth expiration and unify modals

### DIFF
--- a/frontend/components/KeyRevealModal.tsx
+++ b/frontend/components/KeyRevealModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import Modal from "./Modal";
 
 interface KeyRevealModalProps {
   isOpen: boolean;
@@ -18,22 +19,9 @@ export default function KeyRevealModal({
   const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
 
   useEffect(() => {
-    if (!isOpen) return undefined;
+    if (!isOpen) return;
     setCopiedIndex(null);
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onClose();
-      }
-    };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-      document.body.style.overflow = previousOverflow;
-    };
-  }, [isOpen, onClose]);
+  }, [isOpen]);
 
   const safeKeys = useMemo(() => keys.filter(Boolean), [keys]);
 
@@ -45,176 +33,123 @@ export default function KeyRevealModal({
     try {
       await navigator.clipboard.writeText(value);
       setCopiedIndex(index);
-      setTimeout(() => setCopiedIndex((current) => (current === index ? null : current)), 2000);
+      setTimeout(() =>
+        setCopiedIndex((current) => (current === index ? null : current)),
+      2000);
     } catch (error) {
       console.warn("Failed to copy value", error);
     }
   };
 
   return (
-    <div className="overlay" role="presentation" onClick={onClose}>
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="key-reveal-title"
-        className="modal"
-        onClick={(event) => event.stopPropagation()}
-      >
-        <header>
-          <h2 id="key-reveal-title">{title}</h2>
-          <button type="button" className="close" onClick={onClose} aria-label="Close secret reveal">
-            ×
-          </button>
-        </header>
-        <div className="body">
-          {context && <p className="context">{context}</p>}
-          <p className="disclaimer">
-            This is the only time these credentials will ever be displayed. Store them immediately in your
-            team&apos;s password manager or secret vault. We cannot recover them later.
-          </p>
-          <ul>
-            {safeKeys.map((key, index) => (
-              <li key={key}>
-                <code>{key}</code>
-                <button type="button" onClick={() => handleCopy(key, index)}>
-                  {copiedIndex === index ? "Copied" : "Copy"}
-                </button>
-              </li>
-            ))}
-          </ul>
-        </div>
-        <footer>
-          <button type="button" className="primary" onClick={onClose}>
-            I have stored these secrets securely
-          </button>
-        </footer>
-        <style jsx>{`
-          .overlay {
-            position: fixed;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            background: rgba(0, 0, 0, 0.55);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            z-index: 2000;
-            padding: 1.5rem;
-          }
-          .modal {
-            background: #fff;
-            border-radius: 8px;
-            box-shadow: 0 20px 45px rgba(0, 0, 0, 0.2);
-            width: min(640px, 100%);
-            display: flex;
-            flex-direction: column;
-            max-height: 90vh;
-          }
-          header {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            padding: 1rem 1.25rem;
-            border-bottom: 1px solid #f0f0f0;
-          }
-          header h2 {
-            margin: 0;
-            font-size: 1.25rem;
-          }
-          .close {
-            border: none;
-            background: transparent;
-            font-size: 1.5rem;
-            cursor: pointer;
-            line-height: 1;
-            color: #888;
-          }
-          .close:hover {
-            color: #000;
-          }
-          .body {
-            padding: 1rem 1.25rem 0.75rem;
-            display: flex;
-            flex-direction: column;
-            gap: 0.75rem;
-            overflow-y: auto;
-          }
-          .context {
-            margin: 0;
-            color: #333;
-          }
-          .disclaimer {
-            margin: 0;
-            color: #cf1322;
-            font-weight: 500;
-          }
-          ul {
-            list-style: none;
-            margin: 0;
-            padding: 0;
-            display: flex;
-            flex-direction: column;
-            gap: 0.5rem;
-          }
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={title}
+      className="key-reveal-modal"
+      bodyClassName="key-reveal-body"
+      closeLabel="Close secret reveal"
+      footer={
+        <button type="button" className="primary" onClick={onClose}>
+          I have stored these secrets securely
+        </button>
+      }
+    >
+      {context && <p className="context">{context}</p>}
+      <p className="disclaimer">
+        This is the only time these credentials will ever be displayed. Store
+        them immediately in your team&apos;s password manager or secret vault. We
+        cannot recover them later.
+      </p>
+      <ul>
+        {safeKeys.map((key, index) => (
+          <li key={key}>
+            <code>{key}</code>
+            <button type="button" onClick={() => handleCopy(key, index)}>
+              {copiedIndex === index ? "Copied" : "Copy"}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <style jsx>{`
+        :global(.key-reveal-modal) {
+          width: min(640px, 100%);
+        }
+        :global(.key-reveal-body) {
+          display: flex;
+          flex-direction: column;
+          gap: 0.75rem;
+          padding-bottom: 0;
+        }
+        .context {
+          margin: 0;
+          color: #333;
+        }
+        .disclaimer {
+          margin: 0;
+          color: #cf1322;
+          font-weight: 500;
+        }
+        ul {
+          list-style: none;
+          margin: 0;
+          padding: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 0.5rem;
+        }
+        li {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 0.75rem;
+          background: #141414;
+          color: #fff;
+          border-radius: 6px;
+          padding: 0.75rem 1rem;
+          flex-wrap: wrap;
+        }
+        code {
+          font-family: "Fira Code", "SFMono-Regular", Consolas,
+            "Liberation Mono", Menlo, Courier, monospace;
+          font-size: 0.95rem;
+          word-break: break-all;
+          flex: 1 1 auto;
+        }
+        li button {
+          flex: 0 0 auto;
+          border: none;
+          background: #262626;
+          color: #fff;
+          padding: 0.35rem 0.75rem;
+          border-radius: 4px;
+          cursor: pointer;
+        }
+        li button:hover {
+          background: #434343;
+        }
+        .primary {
+          background: #1890ff;
+          color: #fff;
+          border: none;
+          border-radius: 4px;
+          padding: 0.5rem 1rem;
+          cursor: pointer;
+        }
+        .primary:hover {
+          background: #096dd9;
+        }
+        @media (max-width: 480px) {
           li {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            gap: 0.75rem;
-            background: #141414;
-            color: #fff;
-            border-radius: 6px;
-            padding: 0.75rem 1rem;
-            flex-wrap: wrap;
-          }
-          code {
-            font-family: "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
-            font-size: 0.95rem;
-            word-break: break-all;
-            flex: 1 1 auto;
+            flex-direction: column;
+            align-items: flex-start;
           }
           li button {
-            flex: 0 0 auto;
-            border: none;
-            background: #262626;
-            color: #fff;
-            padding: 0.35rem 0.75rem;
-            border-radius: 4px;
-            cursor: pointer;
+            width: 100%;
+            text-align: center;
           }
-          li button:hover {
-            background: #434343;
-          }
-          footer {
-            padding: 1rem 1.25rem 1.25rem;
-            border-top: 1px solid #f0f0f0;
-            display: flex;
-            justify-content: flex-end;
-          }
-          .primary {
-            background: #1890ff;
-            color: #fff;
-            border: none;
-            border-radius: 4px;
-            padding: 0.5rem 1rem;
-            cursor: pointer;
-          }
-          .primary:hover {
-            background: #096dd9;
-          }
-          @media (max-width: 480px) {
-            li {
-              flex-direction: column;
-              align-items: flex-start;
-            }
-            li button {
-              width: 100%;
-              text-align: center;
-            }
-          }
-        `}</style>
-      </div>
-    </div>
+        }
+      `}</style>
+    </Modal>
   );
 }

--- a/frontend/components/Modal.tsx
+++ b/frontend/components/Modal.tsx
@@ -1,0 +1,140 @@
+import { ReactNode, useEffect, useId } from "react";
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: ReactNode;
+  children: ReactNode;
+  footer?: ReactNode;
+  className?: string;
+  bodyClassName?: string;
+  closeLabel?: string;
+  showCloseButton?: boolean;
+}
+
+export default function Modal({
+  isOpen,
+  onClose,
+  title,
+  children,
+  footer,
+  className,
+  bodyClassName,
+  closeLabel = "Close dialog",
+  showCloseButton = true,
+}: ModalProps) {
+  const labelId = useId();
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const shouldRenderHeader = Boolean(title) || showCloseButton;
+
+  return (
+    <div className="modal-overlay" role="presentation" onClick={onClose}>
+      <div
+        className={`modal ${className ?? ""}`.trim()}
+        role="dialog"
+        aria-modal="true"
+        {...(title ? { "aria-labelledby": labelId } : {})}
+        onClick={(event) => event.stopPropagation()}
+      >
+        {shouldRenderHeader && (
+          <header className="modal-header">
+            {title && (
+              <div className="modal-title" id={labelId}>
+                {title}
+              </div>
+            )}
+            {showCloseButton && (
+              <button
+                type="button"
+                className="modal-close"
+                onClick={onClose}
+                aria-label={closeLabel}
+              >
+                ×
+              </button>
+            )}
+          </header>
+        )}
+        <div className={`modal-body ${bodyClassName ?? ""}`.trim()}>{children}</div>
+        {footer && <footer className="modal-footer">{footer}</footer>}
+        <style jsx>{`
+          .modal-overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(0, 0, 0, 0.55);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 2000;
+            padding: 1.5rem;
+          }
+          .modal {
+            background: #fff;
+            border-radius: 8px;
+            box-shadow: 0 20px 45px rgba(0, 0, 0, 0.2);
+            width: min(640px, 100%);
+            max-height: 90vh;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+          }
+          .modal-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 1rem 1.25rem;
+            border-bottom: 1px solid #f0f0f0;
+            gap: 1rem;
+          }
+          .modal-title {
+            font-size: 1.25rem;
+            font-weight: 600;
+          }
+          .modal-close {
+            border: none;
+            background: transparent;
+            font-size: 1.5rem;
+            cursor: pointer;
+            line-height: 1;
+            color: #888;
+          }
+          .modal-close:hover {
+            color: #000;
+          }
+          .modal-body {
+            padding: 1rem 1.25rem;
+            overflow-y: auto;
+          }
+          .modal-footer {
+            padding: 1rem 1.25rem 1.25rem;
+            border-top: 1px solid #f0f0f0;
+            display: flex;
+            justify-content: flex-end;
+            gap: 0.75rem;
+          }
+        `}</style>
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/http.ts
+++ b/frontend/lib/http.ts
@@ -1,0 +1,13 @@
+export class HttpError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "HttpError";
+    this.status = status;
+  }
+}
+
+export function isUnauthorized(status: number) {
+  return status === 401 || status === 403;
+}

--- a/frontend/lib/session.ts
+++ b/frontend/lib/session.ts
@@ -1,0 +1,27 @@
+export const LOGOUT_EVENT_NAME = "wr-auth-logout";
+const LOGIN_ROUTE = "/auth/dev-login";
+const SESSION_STORAGE_KEYS = ["wr_auth_token", "wr_active_org", "apiKey"] as const;
+
+export function clearStoredSession() {
+  if (typeof window === "undefined") return;
+  SESSION_STORAGE_KEYS.forEach((key) => {
+    try {
+      window.localStorage.removeItem(key);
+    } catch (error) {
+      console.warn(`Failed to remove ${key} from storage`, error);
+    }
+  });
+}
+
+export function redirectToLogin() {
+  if (typeof window === "undefined") return;
+  if (window.location.pathname === LOGIN_ROUTE) return;
+  window.location.replace(LOGIN_ROUTE);
+}
+
+export function forceLogoutRedirect() {
+  if (typeof window === "undefined") return;
+  clearStoredSession();
+  window.dispatchEvent(new Event(LOGOUT_EVENT_NAME));
+  redirectToLogin();
+}


### PR DESCRIPTION
## Summary
- add a shared Modal component and switch existing overlays to use it for consistent close behavior
- centralize HTTP error helpers and session logout utilities for reuse
- redirect to login on 401/403 responses across auth context and question/snippet flows to avoid infinite loops

## Testing
- npm run lint --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68cbec0b42708330b49d7242fc759841