### PR TITLE
Add modals for API key workflows and rename CV parser product

### DIFF
--- a/backend/src/products/insightsSandbox/index.ts
+++ b/backend/src/products/insightsSandbox/index.ts
@@ -10,7 +10,7 @@ export function createInsightsSandboxApp() {
   });
 
   app.get("/api/insights", (_req, res) => {
-    res.status(501).json({ error: "Insights Sandbox API is not yet implemented" });
+    res.status(501).json({ error: "CV parser API is not yet implemented" });
   });
 
   return app;

--- a/backend/src/shared/types/Products.ts
+++ b/backend/src/shared/types/Products.ts
@@ -90,9 +90,9 @@ export const PRODUCT_CATALOG: ProductDefinition<ProductKeyConfig>[] = [
   },
   {
     id: INSIGHTS_SANDBOX_PRODUCT_ID,
-    name: "Insights Sandbox",
+    name: "CV parser",
     description:
-      "Placeholder for the upcoming insights workspace. Used to stage analytics access policies before launch.",
+      "It will take CV inputs and output structured data with all relevant info from the resume.",
     defaultConfig: createDefaultInsightsSandboxConfig(),
   },
   {


### PR DESCRIPTION
## Summary
- ask for confirmation before rotating API keys and surface errors through a dedicated modal
- move the new key set form into a modal with validation and loading states
- rename the placeholder Insights Sandbox product to "CV parser" across the catalog

## Testing
- npm run lint --prefix frontend
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68cc5ad50e0483308a5f2beb1ab850e6