### PR TITLE
Separate tenant top-ups from usage reporting

### DIFF
--- a/frontend/lib/usage.ts
+++ b/frontend/lib/usage.ts
@@ -1,0 +1,43 @@
+import type { UsageEntry } from "@/types/account";
+
+export function isTopUpEntry(entry: UsageEntry): boolean {
+  return entry.action === "topup";
+}
+
+export function splitUsageEntries(
+  entries: UsageEntry[],
+): { usage: UsageEntry[]; topUps: UsageEntry[] } {
+  return entries.reduce(
+    (acc, entry) => {
+      if (isTopUpEntry(entry)) {
+        acc.topUps.push(entry);
+      } else {
+        acc.usage.push(entry);
+      }
+      return acc;
+    },
+    { usage: [] as UsageEntry[], topUps: [] as UsageEntry[] },
+  );
+}
+
+export function summarizeTopUps(entries: UsageEntry[]): {
+  totalAmount: number;
+  lastTimestamp: string | null;
+  count: number;
+} {
+  if (entries.length === 0) {
+    return { totalAmount: 0, lastTimestamp: null, count: 0 };
+  }
+  return entries.reduce(
+    (acc, entry) => {
+      const amount = Math.abs(entry.billedCost);
+      acc.totalAmount += amount;
+      acc.count += 1;
+      if (!acc.lastTimestamp || entry.timestamp > acc.lastTimestamp) {
+        acc.lastTimestamp = entry.timestamp;
+      }
+      return acc;
+    },
+    { totalAmount: 0, lastTimestamp: null as string | null, count: 0 },
+  );
+}

--- a/frontend/pages/account/billing.tsx
+++ b/frontend/pages/account/billing.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import KeyRevealModal from "@/components/KeyRevealModal";
 import UsageBreakdown from "@/components/UsageBreakdown";
 import { fetchJSON } from "@/lib/api";
+import { splitUsageEntries, summarizeTopUps } from "@/lib/usage";
 import { OrgRole, SafeApiKey, SafeKeySet, SafeUser, UsageEntry } from "@/types/account";
 import { useAuth } from "@/context/AuthContext";
 import {
@@ -388,9 +389,14 @@ export default function BillingPage() {
     setMemberError(null);
   };
 
-  const organizationUsage = useMemo<UsageEntry[]>(
-    () => organization?.usage ?? [],
+  const { usage: organizationUsage, topUps: organizationTopUps } = useMemo(
+    () => splitUsageEntries(organization?.usage ?? []),
     [organization?.usage],
+  );
+
+  const topUpSummary = useMemo(
+    () => summarizeTopUps(organizationTopUps),
+    [organizationTopUps],
   );
 
   const orgStats = useMemo(
@@ -577,6 +583,30 @@ export default function BillingPage() {
           <section id="section-credits" className="card">
             <h2>Credits &amp; top-ups</h2>
             <p className="metric">${organization.credits.toFixed(2)}</p>
+            <p className="hint">
+              {topUpSummary.count === 0
+                ? "No top-ups have been recorded yet."
+                : `Top-up history: ${topUpSummary.count} ${
+                    topUpSummary.count === 1 ? "top-up" : "top-ups"
+                  } totaling $${topUpSummary.totalAmount.toFixed(2)}${
+                    topUpSummary.lastTimestamp
+                      ? ` (last on ${new Date(topUpSummary.lastTimestamp).toLocaleString()})`
+                      : ""
+                  }.`}
+            </p>
+            {organizationTopUps.length > 0 && (
+              <ul className="topup-history">
+                {organizationTopUps
+                  .slice()
+                  .sort((a, b) => (a.timestamp < b.timestamp ? 1 : -1))
+                  .map((entry, index) => (
+                    <li key={`${entry.timestamp}-${index}`}>
+                      <span>{new Date(entry.timestamp).toLocaleString()}</span>
+                      <span className="amount">+${Math.abs(entry.billedCost).toFixed(2)}</span>
+                    </li>
+                  ))}
+              </ul>
+            )}
             {canManageBilling ? (
               <div className="topup">
                 <input
@@ -1325,6 +1355,27 @@ export default function BillingPage() {
           margin: 0;
           font-size: 0.9rem;
           color: #666;
+        }
+        .topup-history {
+          margin: 0.5rem 0;
+          padding: 0;
+          list-style: none;
+          display: grid;
+          gap: 0.25rem;
+        }
+        .topup-history li {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          background: #f7f9fc;
+          border: 1px solid #eef2f7;
+          border-radius: 4px;
+          padding: 0.35rem 0.5rem;
+          font-size: 0.9rem;
+        }
+        .topup-history .amount {
+          font-weight: 600;
+          color: #237804;
         }
         .topup {
           display: flex;


### PR DESCRIPTION
## Summary
- add shared helpers to split usage events from top-ups
- filter billing usage views to exclude top-ups and show a dedicated top-up history list
- update the admin console usage panel to surface top-up summaries separately from request usage

## Testing
- npm run lint --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68cc686211008330a234ee1847afc2ac