### PR TITLE
Implement question set draft workflow and permissions

### DIFF
--- a/backend/src/products/documentAnalysis/routes/uploadRoute.ts
+++ b/backend/src/products/documentAnalysis/routes/uploadRoute.ts
@@ -135,7 +135,18 @@ router.post("/", upload, async (req, res) => {
         title,
         id,
         executionPlanReasoning,
+        status,
       } = await loadQuestionSet(orgId, questionSetId);
+
+      if (status !== "active") {
+        sendError(
+          new Error(
+            "Question set must be active before snippets can be evaluated.",
+          ),
+        );
+        res.end();
+        return;
+      }
 
       if (!questions.length) {
         sendEvent("error", { message: "No questions defined." });
@@ -198,9 +209,19 @@ router.post("/", upload, async (req, res) => {
     sendLog(`Received ${snippets.length} snippets.`);
 
     // Load question set
-      const questionSet = await loadQuestionSet(orgId, questionSetId);
+    const questionSet = await loadQuestionSet(orgId, questionSetId);
     if (!questionSet) {
       sendError(new Error(`Question set with ID ${questionSetId} not found.`));
+      res.end();
+      return;
+    }
+
+    if (questionSet.status !== "active") {
+      sendError(
+        new Error(
+          "Question set must be active before snippets can be evaluated.",
+        ),
+      );
       res.end();
       return;
     }

--- a/backend/src/shared/types/Products.ts
+++ b/backend/src/shared/types/Products.ts
@@ -11,6 +11,8 @@ export type ProductId =
 
 export type DocumentAnalysisPermission =
   | "createQuestionSet"
+  | "editQuestionSet"
+  | "manageQuestionSetActivation"
   | "evaluateDocument";
 
 export interface DocumentAnalysisProductConfig {
@@ -53,6 +55,10 @@ export function createDefaultDocumentAnalysisConfig(
     productId: DOCUMENT_ANALYSIS_PRODUCT_ID,
     permissions: {
       createQuestionSet: Boolean(overrides.createQuestionSet),
+      editQuestionSet: Boolean(overrides.editQuestionSet),
+      manageQuestionSetActivation: Boolean(
+        overrides.manageQuestionSetActivation,
+      ),
       evaluateDocument: Boolean(overrides.evaluateDocument),
     },
   };

--- a/backend/src/shared/types/Questions.ts
+++ b/backend/src/shared/types/Questions.ts
@@ -91,6 +91,20 @@ export type Question =
   | ListQuestion
   | OpenEndedQuestion;
 
+export type QuestionSetStatus = "draft" | "active" | "inactive";
+
+export type QuestionSetActor =
+  | {
+      type: "user";
+      id: string;
+      label?: string | null;
+    }
+  | {
+      type: "apiKey";
+      id: string;
+      label?: string | null;
+    };
+
 export interface QuestionSet {
   id: string;
   executionPlan: string;
@@ -100,6 +114,12 @@ export interface QuestionSet {
   qaResults: QAResult[];
   title: string;
   originalUserInput: string; // Original user input that triggered this question set
+  status: QuestionSetStatus;
+  createdAt: string;
+  updatedAt: string;
+  finalizedAt: string | null;
+  createdBy: QuestionSetActor | null;
+  lastModifiedBy: QuestionSetActor | null;
 }
 
 /**

--- a/backend/src/shared/utils/questionStore.ts
+++ b/backend/src/shared/utils/questionStore.ts
@@ -1,11 +1,215 @@
 import fs from "fs/promises";
 import path from "path";
-import { QAResult, QuestionSet } from "../types/Questions";
+import {
+  QAResult,
+  QuestionSet,
+  QuestionSetActor,
+  QuestionSetStatus,
+} from "../types/Questions";
 
 const PROJECT_ROOT = path.resolve(__dirname, "../../../..");
 const QUESTIONS_ROOT = path.join(PROJECT_ROOT, "data/questions");
 const QA_RESULTS_ROOT = path.join(PROJECT_ROOT, "data/qaResults");
 const FILE_PREFIX = "questions-";
+
+type StoredQuestionSet = Omit<QuestionSet, "qaResults">;
+
+function isQuestionSetStatus(value: unknown): value is QuestionSetStatus {
+  return value === "draft" || value === "active" || value === "inactive";
+}
+
+function toActor(value: unknown): QuestionSetActor | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const candidate = value as {
+    type?: unknown;
+    id?: unknown;
+    label?: unknown;
+  };
+  if (candidate.type !== "user" && candidate.type !== "apiKey") {
+    return null;
+  }
+  if (typeof candidate.id !== "string" || !candidate.id) {
+    return null;
+  }
+  const actor: QuestionSetActor = {
+    type: candidate.type,
+    id: candidate.id,
+  };
+  if (
+    "label" in candidate &&
+    (typeof candidate.label === "string" || candidate.label === null)
+  ) {
+    actor.label = candidate.label;
+  }
+  return actor;
+}
+
+function ensureIsoString(value: unknown, fallback: string): string {
+  if (typeof value === "string" && value) {
+    const timestamp = Date.parse(value);
+    if (!Number.isNaN(timestamp)) {
+      return new Date(timestamp).toISOString();
+    }
+  }
+  return fallback;
+}
+
+function parseQuestionFilename(filename: string):
+  | {
+      safeId: string;
+      id: string;
+      title: string;
+      questionCount: number;
+    }
+  | null {
+  if (filename.startsWith(".DELETED_")) return null;
+  if (!filename.startsWith(FILE_PREFIX) || !filename.endsWith(".json")) {
+    return null;
+  }
+  const basename = filename.slice(FILE_PREFIX.length, -5);
+  const parts = basename.split("-");
+  if (parts.length !== 3) return null;
+  const [safeTitle, safeId, countStr] = parts;
+  const id = toUnsafeSegment(safeId);
+  const title = toUnsafeSegment(safeTitle);
+  const questionCount = Number(countStr);
+  if (!Number.isFinite(questionCount)) {
+    return null;
+  }
+  return { safeId, id, title, questionCount };
+}
+
+async function findQuestionSetFile(orgId: string, id: string) {
+  const dir = getQuestionsDirForOrg(orgId);
+  let files: string[];
+  try {
+    files = await fs.readdir(dir);
+  } catch {
+    throw new Error("No question sets found");
+  }
+  const safeId = toSafeSegment(id);
+  for (const file of files) {
+    const parsed = parseQuestionFilename(file);
+    if (parsed && parsed.safeId === safeId) {
+      return { dir, filename: file, parsed };
+    }
+  }
+  throw new Error(`Question set with id ${id} not found`);
+}
+
+function normalizeQuestionSetRecord(
+  raw: Partial<StoredQuestionSet>,
+  defaults: {
+    id: string;
+    title: string;
+    createdAt: string;
+    updatedAt: string;
+  },
+): StoredQuestionSet {
+  const createdAt = ensureIsoString(raw.createdAt, defaults.createdAt);
+  const updatedAt = ensureIsoString(raw.updatedAt, defaults.updatedAt);
+  const status = isQuestionSetStatus(raw.status) ? raw.status : "active";
+  const finalizedAtRaw =
+    status === "draft"
+      ? null
+      : raw.finalizedAt === null
+      ? null
+      : ensureIsoString(raw.finalizedAt, updatedAt);
+  return {
+    id: raw.id || defaults.id,
+    title: raw.title || defaults.title,
+    executionPlan: raw.executionPlan || "",
+    executionPlanReasoning: raw.executionPlanReasoning || "",
+    snippetType: raw.snippetType || "",
+    questions: Array.isArray(raw.questions) ? raw.questions : [],
+    originalUserInput: raw.originalUserInput || "",
+    status,
+    createdAt,
+    updatedAt,
+    finalizedAt: status === "draft" ? null : finalizedAtRaw,
+    createdBy: toActor(raw.createdBy),
+    lastModifiedBy: toActor(raw.lastModifiedBy) || toActor(raw.createdBy),
+  };
+}
+
+async function removeExistingQuestionSetFiles(orgId: string, id: string) {
+  const dir = getQuestionsDirForOrg(orgId);
+  let files: string[];
+  try {
+    files = await fs.readdir(dir);
+  } catch {
+    return;
+  }
+  const safeId = toSafeSegment(id);
+  await Promise.all(
+    files
+      .filter((file) => !file.startsWith(".DELETED_"))
+      .map((file) => ({ file, parsed: parseQuestionFilename(file) }))
+      .filter((entry) => entry.parsed && entry.parsed.safeId === safeId)
+      .map((entry) => fs.unlink(path.join(dir, entry.file))),
+  );
+}
+
+async function readQuestionSetFile(
+  orgId: string,
+  dir: string,
+  filename: string,
+  parsed: NonNullable<ReturnType<typeof parseQuestionFilename>>,
+): Promise<StoredQuestionSet> {
+  const filePath = path.join(dir, filename);
+  const raw = await fs.readFile(filePath, "utf-8");
+  const data = JSON.parse(raw) as Partial<StoredQuestionSet> & {
+    orgId?: string;
+  };
+  if (data.orgId && data.orgId !== orgId) {
+    throw new Error("Question set does not belong to this organization");
+  }
+  const stat = await fs.stat(filePath);
+  const defaults = {
+    id: parsed.id,
+    title: parsed.title,
+    createdAt: stat.birthtime
+      ? new Date(stat.birthtime).toISOString()
+      : new Date().toISOString(),
+    updatedAt: stat.mtime
+      ? new Date(stat.mtime).toISOString()
+      : new Date().toISOString(),
+  };
+  return normalizeQuestionSetRecord({ ...data, id: data.id || parsed.id }, defaults);
+}
+
+async function loadQuestionSetRecord(
+  orgId: string,
+  id: string,
+): Promise<StoredQuestionSet> {
+  const context = await findQuestionSetFile(orgId, id);
+  return readQuestionSetFile(orgId, context.dir, context.filename, context.parsed);
+}
+
+async function writeQuestionSetRecord(
+  orgId: string,
+  record: StoredQuestionSet,
+): Promise<void> {
+  const dir = getQuestionsDirForOrg(orgId);
+  await fs.mkdir(dir, { recursive: true });
+  await removeExistingQuestionSetFiles(orgId, record.id);
+  const rawTitle = record.title || "untitled";
+  const questionCount = record.questions.length;
+  const safeTitle = toSafeSegment(rawTitle);
+  const safeId = toSafeSegment(record.id);
+  const filename = `${FILE_PREFIX}${safeTitle}-${safeId}-${questionCount}.json`;
+  const payload = {
+    ...record,
+    orgId,
+  };
+  await fs.writeFile(
+    path.join(dir, filename),
+    JSON.stringify(payload, null, 2),
+    "utf-8",
+  );
+}
 
 function toSafeSegment(value: string): string {
   return encodeURIComponent(value).replace(/-/g, "%2D");
@@ -34,72 +238,41 @@ export async function loadQuestionSet(
   if (!id) {
     throw new Error("No question set ID provided");
   }
-
-  const dir = getQuestionsDirForOrg(orgId);
-  let files: string[];
-  try {
-    files = await fs.readdir(dir);
-  } catch {
-    throw new Error("No question sets found");
-  }
-
-  const safeId = toSafeSegment(id);
-  const filename = files.find((file) => {
-    if (!file.startsWith(FILE_PREFIX) || !file.endsWith(".json")) return false;
-    const basename = file.slice(FILE_PREFIX.length, -5);
-    const parts = basename.split("-");
-    return parts.length === 3 && parts[1] === safeId;
-  });
-  if (!filename) {
-    throw new Error(`Question set with id ${id} not found`);
-  }
-  const raw = await fs.readFile(path.join(dir, filename), "utf-8");
-  const parsed = JSON.parse(raw) as Omit<QuestionSet, "qaResults"> & {
-    orgId?: string;
-  };
-
-  if (parsed.orgId && parsed.orgId !== orgId) {
-    throw new Error("Question set does not belong to this organization");
-  }
-
-  const { orgId: _ignoredOrgId, ...questionSet } = parsed;
+  const record = await loadQuestionSetRecord(orgId, id);
 
   const qaResults = await listQaResults(orgId, {
-    questionSetId: questionSet.id,
+    questionSetId: record.id,
   });
 
   return {
-    ...questionSet,
+    ...record,
     qaResults,
   };
 }
 
 export async function saveQuestionSet(
   orgId: string,
-  store: Omit<QuestionSet, "qaResults">,
+  store: StoredQuestionSet,
 ): Promise<void> {
-  const dir = getQuestionsDirForOrg(orgId);
-  await fs.mkdir(dir, { recursive: true });
-  const rawTitle = store.title || "untitled";
-  const questionCount = store.questions.length;
-  const safeTitle = toSafeSegment(rawTitle);
-  const safeId = toSafeSegment(store.id);
-  const filename = `${FILE_PREFIX}${safeTitle}-${safeId}-${questionCount}.json`;
-  const payload = {
-    ...store,
-    orgId,
-  };
-  await fs.writeFile(
-    path.join(dir, filename),
-    JSON.stringify(payload, null, 2),
-    "utf-8",
-  );
+  await writeQuestionSetRecord(orgId, store);
 }
 
 export async function listQuestionSets(
   orgId: string,
   titleFilter?: string,
-): Promise<{ id: string; title: string; date: Date; questionCount: number }[]> {
+): Promise<
+  {
+    id: string;
+    title: string;
+    date: Date;
+    questionCount: number;
+    snippetCount: number;
+    status: QuestionSetStatus;
+    createdAt: string;
+    updatedAt: string;
+    finalizedAt: string | null;
+  }[]
+> {
   const qaResults = await listQaResults(orgId);
   const qaResultsByQuestionSetId = {} as Record<string, QAResult[]>;
   for (const qaResult of qaResults) {
@@ -122,26 +295,26 @@ export async function listQuestionSets(
     date: Date;
     questionCount: number;
     snippetCount: number;
+    status: QuestionSetStatus;
+    createdAt: string;
+    updatedAt: string;
+    finalizedAt: string | null;
   }[] = [];
 
   for (const file of files) {
-    if (file.startsWith(".DELETED_")) continue;
-    if (!file.startsWith(FILE_PREFIX) || !file.endsWith(".json")) continue;
-    const basename = file.slice(FILE_PREFIX.length, -5);
-    const parts = basename.split("-");
-    if (parts.length !== 3) continue;
-    const [safeTitle, safeId, countStr] = parts;
-    const title = toUnsafeSegment(safeTitle);
-    const id = toUnsafeSegment(safeId);
-    const questionCount = Number(countStr);
-    const stat = await fs.stat(path.join(dir, file));
-
+    const parsed = parseQuestionFilename(file);
+    if (!parsed) continue;
+    const record = await readQuestionSetFile(orgId, dir, file, parsed);
     result.push({
-      id,
-      title,
-      date: stat.mtime,
-      questionCount,
-      snippetCount: qaResultsByQuestionSetId[id]?.length || 0,
+      id: record.id,
+      title: record.title,
+      date: new Date(record.updatedAt),
+      questionCount: record.questions.length,
+      snippetCount: qaResultsByQuestionSetId[record.id]?.length || 0,
+      status: record.status,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+      finalizedAt: record.finalizedAt,
     });
   }
   if (titleFilter) {
@@ -151,6 +324,67 @@ export async function listQuestionSets(
     );
   }
   return result;
+}
+
+export async function updateQuestionSet(
+  orgId: string,
+  id: string,
+  mutate: (
+    record: StoredQuestionSet,
+  ) => StoredQuestionSet | Promise<StoredQuestionSet>,
+): Promise<QuestionSet> {
+  const current = await loadQuestionSetRecord(orgId, id);
+  const draft = JSON.parse(JSON.stringify(current)) as StoredQuestionSet;
+  const next = await mutate(draft);
+  const payload: StoredQuestionSet = {
+    ...current,
+    ...next,
+    id: current.id,
+    createdAt: next.createdAt || current.createdAt,
+    createdBy: next.createdBy ?? current.createdBy,
+  };
+  await writeQuestionSetRecord(orgId, payload);
+  const saved = await loadQuestionSetRecord(orgId, id);
+  const qaResults = await listQaResults(orgId, { questionSetId: saved.id });
+  return { ...saved, qaResults };
+}
+
+export async function finalizeQuestionSet(
+  orgId: string,
+  id: string,
+  actor: QuestionSetActor | null,
+): Promise<QuestionSet> {
+  return updateQuestionSet(orgId, id, (record) => {
+    const timestamp = new Date().toISOString();
+    return {
+      ...record,
+      status: "active",
+      finalizedAt: timestamp,
+      updatedAt: timestamp,
+      lastModifiedBy: actor ?? record.lastModifiedBy ?? record.createdBy,
+    };
+  });
+}
+
+export async function setQuestionSetActivation(
+  orgId: string,
+  id: string,
+  active: boolean,
+  actor: QuestionSetActor | null,
+): Promise<QuestionSet> {
+  return updateQuestionSet(orgId, id, (record) => {
+    if (!record.finalizedAt) {
+      throw new Error("Question set has not been finalized yet");
+    }
+    const timestamp = new Date().toISOString();
+    return {
+      ...record,
+      status: active ? "active" : "inactive",
+      updatedAt: timestamp,
+      finalizedAt: record.finalizedAt || timestamp,
+      lastModifiedBy: actor ?? record.lastModifiedBy ?? record.createdBy,
+    };
+  });
 }
 
 export const loadQaResult = async (

--- a/backend/src/shared/utils/snippetProcessor.ts
+++ b/backend/src/shared/utils/snippetProcessor.ts
@@ -14,7 +14,18 @@ export async function processSnippets(
   rows: RecordRow[] | null,
   snippets: { id: string; name: string; content: string }[] | null,
   // either fullSnippet or rows must be provided
+  questionSet: QuestionSet,
   {
+    sendLog,
+    sendEvent,
+    sendError,
+    }: {
+    sendLog: (msg: string, snippetId?: string) => void;
+    sendEvent: (event: string, data: any) => void;
+    sendError: (error: any) => void;
+  }
+): Promise<QAResult[]> {
+  const {
     questions,
     originalUserInput,
     executionPlan,
@@ -22,17 +33,8 @@ export async function processSnippets(
     snippetType,
     title,
     id: questionSetId,
-  }: QuestionSet,
-  {
-    sendLog,
-    sendEvent,
-    sendError,
-  }: {
-    sendLog: (msg: string, snippetId?: string) => void;
-    sendEvent: (event: string, data: any) => void;
-    sendError: (error: any) => void;
-  }
-): Promise<QAResult[]> {
+  } = questionSet;
+
   let resultPromises: Promise<QAResult>[] = [];
   console.log(
     "Processing snippets with rows:",
@@ -111,15 +113,9 @@ export async function processSnippets(
           .join("\n");
         const { answers, metrics } = await orchestratorAgent(
           {
-            originalUserInput,
+            ...questionSet,
             snippetId,
             fullSnippet,
-            questions,
-            executionPlan,
-            executionPlanReasoning,
-            snippetType,
-            title,
-            id: questionSetId,
             qaResults: [],
           },
           { sendLog: sendConvLog, sendEvent, sendError },
@@ -178,15 +174,9 @@ export async function processSnippets(
 
     const { answers, metrics } = await orchestratorAgent(
       {
-        originalUserInput,
+        ...questionSet,
         snippetId,
         fullSnippet: content,
-        questions,
-        executionPlan,
-        executionPlanReasoning,
-        snippetType,
-        title,
-        id: questionSetId,
         qaResults: [],
       },
       { sendLog: sendSnippetLog, sendEvent, sendError },

--- a/backend/src/shared/utils/userStore/apiKeys.ts
+++ b/backend/src/shared/utils/userStore/apiKeys.ts
@@ -48,6 +48,8 @@ export function createDefaultKeySet(actorId: string): KeySet {
     products: [
       createDefaultDocumentAnalysisConfig({
         createQuestionSet: true,
+        editQuestionSet: true,
+        manageQuestionSetActivation: true,
         evaluateDocument: true,
       }),
     ],

--- a/backend/src/shared/utils/userStore/productConfig.ts
+++ b/backend/src/shared/utils/userStore/productConfig.ts
@@ -26,6 +26,10 @@ function coerceDocumentPermissions(
   const permissions = input.permissions ?? {};
   return {
     createQuestionSet: Boolean(permissions.createQuestionSet),
+    editQuestionSet: Boolean(permissions.editQuestionSet),
+    manageQuestionSetActivation: Boolean(
+      permissions.manageQuestionSetActivation,
+    ),
     evaluateDocument: Boolean(permissions.evaluateDocument),
   };
 }
@@ -157,6 +161,8 @@ export function normalizeProductConfigs(
     normalized.push(
       createDefaultDocumentAnalysisConfig({
         createQuestionSet: true,
+        editQuestionSet: true,
+        manageQuestionSetActivation: true,
         evaluateDocument: true,
       }),
     );

--- a/backend/test/productConfig.test.ts
+++ b/backend/test/productConfig.test.ts
@@ -26,6 +26,11 @@ test("default product config helpers coerce overrides", () => {
   });
   assert.equal(documentConfig.productId, DOCUMENT_ANALYSIS_PRODUCT_ID);
   assert.equal(documentConfig.permissions.createQuestionSet, true);
+  assert.equal(documentConfig.permissions.editQuestionSet, false);
+  assert.equal(
+    documentConfig.permissions.manageQuestionSetActivation,
+    false,
+  );
   assert.equal(documentConfig.permissions.evaluateDocument, false);
   assert.equal(isDocumentAnalysisConfig(documentConfig), true);
 
@@ -54,7 +59,7 @@ test("normalizeProductConfigs deduplicates and fills defaults", () => {
   const normalized = normalizeProductConfigs([
     {
       productId: DOCUMENT_ANALYSIS_PRODUCT_ID,
-      permissions: { createQuestionSet: "yes" },
+      permissions: { createQuestionSet: "yes", editQuestionSet: 1 },
     },
     {
       productId: DOCUMENT_ANALYSIS_PRODUCT_ID,
@@ -84,6 +89,8 @@ test("normalizeProductConfigs deduplicates and fills defaults", () => {
   assert.equal(isDocumentAnalysisConfig(document), true);
   if (isDocumentAnalysisConfig(document)) {
     assert.equal(document.permissions.createQuestionSet, true);
+    assert.equal(document.permissions.editQuestionSet, true);
+    assert.equal(document.permissions.manageQuestionSetActivation, false);
     assert.equal(document.permissions.evaluateDocument, false);
   }
 
@@ -129,6 +136,8 @@ test("normalizeProductConfigs adds document analysis when missing", () => {
   assert.equal(isDocumentAnalysisConfig(document), true);
   if (isDocumentAnalysisConfig(document)) {
     assert.equal(document.permissions.createQuestionSet, true);
+    assert.equal(document.permissions.editQuestionSet, true);
+    assert.equal(document.permissions.manageQuestionSetActivation, true);
     assert.equal(document.permissions.evaluateDocument, true);
   }
 });
@@ -146,6 +155,11 @@ test("getProductCatalog returns deep clones of definitions", () => {
   assert.equal(isDocumentAnalysisConfig(secondDefault), true);
   if (isDocumentAnalysisConfig(secondDefault)) {
     assert.equal(secondDefault.permissions.createQuestionSet, false);
+    assert.equal(secondDefault.permissions.editQuestionSet, false);
+    assert.equal(
+      secondDefault.permissions.manageQuestionSetActivation,
+      false,
+    );
   }
 
   const catalogDefault = PRODUCT_CATALOG[0].defaultConfig;
@@ -153,5 +167,10 @@ test("getProductCatalog returns deep clones of definitions", () => {
   assert.equal(isDocumentAnalysisConfig(catalogDefault), true);
   if (isDocumentAnalysisConfig(catalogDefault)) {
     assert.equal(catalogDefault.permissions.createQuestionSet, false);
+    assert.equal(catalogDefault.permissions.editQuestionSet, false);
+    assert.equal(
+      catalogDefault.permissions.manageQuestionSetActivation,
+      false,
+    );
   }
 });

--- a/frontend/pages/account/billing.tsx
+++ b/frontend/pages/account/billing.tsx
@@ -96,6 +96,25 @@ function ProductAccessConfigurator({
             <label>
               <input
                 type="checkbox"
+                checked={documentProductConfig.permissions.editQuestionSet}
+                onChange={(e) =>
+                  onUpdate(DOCUMENT_ANALYSIS_PRODUCT_ID, (config) => {
+                    if (!isDocumentAnalysisConfig(config)) return config;
+                    return {
+                      ...config,
+                      permissions: {
+                        ...config.permissions,
+                        editQuestionSet: e.target.checked,
+                      },
+                    };
+                  })
+                }
+              />
+              Allow editing existing question sets
+            </label>
+            <label>
+              <input
+                type="checkbox"
                 checked={documentProductConfig.permissions.evaluateDocument}
                 onChange={(e) =>
                   onUpdate(DOCUMENT_ANALYSIS_PRODUCT_ID, (config) => {
@@ -111,6 +130,27 @@ function ProductAccessConfigurator({
                 }
               />
               Allow document evaluation
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={
+                  documentProductConfig.permissions.manageQuestionSetActivation
+                }
+                onChange={(e) =>
+                  onUpdate(DOCUMENT_ANALYSIS_PRODUCT_ID, (config) => {
+                    if (!isDocumentAnalysisConfig(config)) return config;
+                    return {
+                      ...config,
+                      permissions: {
+                        ...config.permissions,
+                        manageQuestionSetActivation: e.target.checked,
+                      },
+                    };
+                  })
+                }
+              />
+              Allow activation management
             </label>
           </fieldset>
         )}
@@ -229,7 +269,12 @@ export default function BillingPage() {
       : [
           {
             productId: DOCUMENT_ANALYSIS_PRODUCT_ID,
-            permissions: { createQuestionSet: true, evaluateDocument: true },
+            permissions: {
+              createQuestionSet: true,
+              editQuestionSet: true,
+              manageQuestionSetActivation: true,
+              evaluateDocument: true,
+            },
           },
           {
             productId: CV_PARSER_PRODUCT_ID,
@@ -248,6 +293,8 @@ export default function BillingPage() {
           permissions: {
             ...config.permissions,
             createQuestionSet: true,
+            editQuestionSet: true,
+            manageQuestionSetActivation: true,
             evaluateDocument: true,
           },
         };
@@ -406,6 +453,12 @@ export default function BillingPage() {
       const grants = [] as string[];
       if (product.permissions.createQuestionSet) {
         grants.push("create question sets");
+      }
+      if (product.permissions.editQuestionSet) {
+        grants.push("edit question sets");
+      }
+      if (product.permissions.manageQuestionSetActivation) {
+        grants.push("manage activation");
       }
       if (product.permissions.evaluateDocument) {
         grants.push("evaluate documents");

--- a/frontend/pages/questions.tsx
+++ b/frontend/pages/questions.tsx
@@ -148,6 +148,13 @@ const QuestionSetPage: React.FC<
       return finalizedAt;
     }
   }, [finalizedAt]);
+  type ConfirmationState =
+    | { type: "save" }
+    | { type: "finalize" }
+    | { type: "activation"; nextActive: boolean };
+  const [confirmation, setConfirmation] = useState<ConfirmationState | null>(
+    null,
+  );
   const confirmationContent = useMemo(() => {
     if (!confirmation) return null;
     switch (confirmation.type) {
@@ -249,13 +256,6 @@ const QuestionSetPage: React.FC<
   const [countdown, setCountdown] = useState<number>(0);
   const [timerCanceled, setTimerCanceled] = useState<boolean>(false);
 
-  type ConfirmationState =
-    | { type: "save" }
-    | { type: "finalize" }
-    | { type: "activation"; nextActive: boolean };
-  const [confirmation, setConfirmation] = useState<ConfirmationState | null>(
-    null,
-  );
   const [isProcessingAction, setIsProcessingAction] = useState(false);
 
   useEffect(() => {

--- a/frontend/types/Questions.ts
+++ b/frontend/types/Questions.ts
@@ -91,6 +91,20 @@ export type Question =
   | ListQuestion
   | OpenEndedQuestion;
 
+export type QuestionSetStatus = "draft" | "active" | "inactive";
+
+export type QuestionSetActor =
+  | {
+      type: "user";
+      id: string;
+      label?: string | null;
+    }
+  | {
+      type: "apiKey";
+      id: string;
+      label?: string | null;
+    };
+
 export interface QuestionSet {
   id: string;
   executionPlan: string;
@@ -99,6 +113,13 @@ export interface QuestionSet {
   questions: Question[];
   qaResults: QAResult[];
   title: string;
+  originalUserInput: string;
+  status: QuestionSetStatus;
+  createdAt: string;
+  updatedAt: string;
+  finalizedAt: string | null;
+  createdBy: QuestionSetActor | null;
+  lastModifiedBy: QuestionSetActor | null;
 }
 
 /**

--- a/frontend/types/products.ts
+++ b/frontend/types/products.ts
@@ -11,6 +11,8 @@ export type ProductId =
 
 export type DocumentAnalysisPermission =
   | "createQuestionSet"
+  | "editQuestionSet"
+  | "manageQuestionSetActivation"
   | "evaluateDocument";
 
 export type DocumentAnalysisProductConfig = {


### PR DESCRIPTION
## Summary
- add status metadata, actor tracking, and finalize/activation helpers to question storage with matching API routes and permission checks
- require active question sets for snippet evaluation and surface draft/activation states in the questions UI with confirmation prompts
- expose edit and activation permissions across shared types and billing configuration so keys can manage finalized sets appropriately

## Testing
- npm run lint --prefix frontend
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68cc74c499c88330bcfb73a719ab88e0