### PR TITLE
Add strict classification answer enforcement toggle

### DIFF
--- a/backend/src/shared/llmCalls/classificationAnswerGenerator.ts
+++ b/backend/src/shared/llmCalls/classificationAnswerGenerator.ts
@@ -29,14 +29,22 @@ export async function classificationAnswerGenerator(
     description,
     // classification-specific fields
     choices,
+    strict,
     // shared guidance fields
     questionText,
   } = question as ClassificationQuestion;
 
-  const choiceLabels = choices.map((c) => c.label).join(", ");
+  const choiceLabelsList = choices.map((c) => c.label);
+  const choiceLabels = choiceLabelsList.join(", ");
   const choiceCriteria = choices
     .map((c) => `- ${c.label}: ${c.criteria}`)
     .join("\n");
+
+  const enforceEnum = Boolean(strict);
+  const shortAnswerSchema =
+    enforceEnum && choiceLabelsList.length > 0
+      ? { type: "string", enum: choiceLabelsList }
+      : { type: "string" };
 
   const answerPrompt: OpenAI.ChatCompletionMessageParam[] = [
     {
@@ -92,7 +100,7 @@ ${getGroupedReasoningWarning(questions, question)}
             properties: {
               reasoning: { type: "string" },
               detailed_answer: { type: "string" },
-              short_answer: { type: "string" },
+              short_answer: shortAnswerSchema,
             },
             required: ["reasoning", "detailed_answer", "short_answer"],
             additionalProperties: false,

--- a/backend/src/shared/llmCalls/classificationQuestionFinalizer.ts
+++ b/backend/src/shared/llmCalls/classificationQuestionFinalizer.ts
@@ -43,6 +43,9 @@ interface ClassificationQuestion extends BaseQuestion {
     label: string; // e.g., "Yes", "No", "Partially", "N/A"
     criteria: string; // describe here the criteria for this choice in great detail, over multiple sentences to allow definite classification
   }>;
+
+  // Optional flag to force the downstream answer generator to respond with one of the labels via an enum schema.
+  strict?: boolean;
 }
 
 interface BaseQuestion {
@@ -117,6 +120,7 @@ ${JSON.stringify(failedAttemptResult)}
                     additionalProperties: false,
                   },
                 },
+                strict: { type: "boolean" },
                 choices: {
                   type: "array",
                   items: {
@@ -147,9 +151,16 @@ ${JSON.stringify(failedAttemptResult)}
       }
     );
 
-    const question = JSON.parse(
+    const rawQuestion = JSON.parse(
       response.choices[0].message.content || "{}"
-    ) as ClassificationQuestion;
+    ) as ClassificationQuestion & { strict?: unknown };
+
+    const question: ClassificationQuestion = {
+      ...rawQuestion,
+      ...(typeof rawQuestion.strict === "boolean"
+        ? { strict: rawQuestion.strict }
+        : {}),
+    };
     return { result: { question }, totalCost };
   } catch (error) {
     sendError(`Error in classification finalizer: ${error}`);

--- a/backend/src/shared/types/Questions.ts
+++ b/backend/src/shared/types/Questions.ts
@@ -38,6 +38,8 @@ export interface ClassificationQuestion extends BaseQuestion {
     label: string; // e.g., "Yes", "No", "Partially", "N/A"
     criteria: string; // definitive and exhaustive criteria describing when the label applies. Needs to describe the criteria in great detail
   }>;
+
+  strict?: boolean; // When true, force the short answer schema to use an enum of the labels
 }
 
 // B) Scale questions

--- a/frontend/pages/questions.tsx
+++ b/frontend/pages/questions.tsx
@@ -1329,6 +1329,37 @@ const QuestionSetPage: React.FC<
                         + Add choice
                       </button>
                     )}
+                    <h3 className="details-section-header">
+                      Strict short answer enforcement
+                    </h3>
+                    <label className="strict-toggle">
+                      <input
+                        type="checkbox"
+                        className="details-field"
+                        disabled={!editingDetails}
+                        checked={Boolean(selectedQuestion.strict)}
+                        onChange={(e) => {
+                          if (!selectedQuestion || !canEditCurrentSet) return;
+                          const strict = e.target.checked;
+                          updateQuestionSetField((prev) => ({
+                            ...prev,
+                            questions: prev.questions.map((q) =>
+                              q.questionId === selectedQuestion.questionId
+                                ? { ...q, strict }
+                                : q,
+                            ),
+                          }));
+                        }}
+                      />
+                      <span>
+                        Force the model to return exactly one of the defined
+                        labels via the response schema.
+                      </span>
+                    </label>
+                    <p className="strict-toggle-description">
+                      When disabled, the model still sees the labels in the
+                      prompt but can technically emit free-form text.
+                    </p>
                   </>
                 )}
 
@@ -2591,6 +2622,20 @@ const QuestionSetPage: React.FC<
         .details-field.choice.range-title {
           flex: 1;
           white-space: nowrap;
+        }
+
+        .strict-toggle {
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+        }
+        .strict-toggle span {
+          font-size: 0.95rem;
+        }
+        .strict-toggle-description {
+          font-size: 0.875rem;
+          color: #666;
+          margin-top: 0.5rem;
         }
 
         /* Force no gap for markdown list headers (scale and classification ranges) */

--- a/frontend/types/Questions.ts
+++ b/frontend/types/Questions.ts
@@ -38,6 +38,8 @@ export interface ClassificationQuestion extends BaseQuestion {
     label: string; // e.g., "Yes", "No", "Partially", "N/A"
     criteria: string; // definitive and exhaustive criteria describing when the label applies. Needs to describe the criteria in great detail
   }>;
+
+  strict?: boolean; // When true, force the short answer schema to use an enum of the labels
 }
 
 // B) Scale questions


### PR DESCRIPTION
## Summary
- add an optional `strict` flag to classification questions and allow the finalizer schema to emit it safely
- teach the classification answer generator to enforce an enum short answer schema when the flag is enabled
- surface a strict-mode toggle in the question editor UI with helper styling

## Testing
- ./test.sh
- npm run lint --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68cd2b2927648330954efd79f338722a